### PR TITLE
remove garbage binary character from start of toxic_chemicals.json

### DIFF
--- a/data/science/toxic_chemicals.json
+++ b/data/science/toxic_chemicals.json
@@ -1,4 +1,4 @@
-﻿{			
+{			
 	"chemicals" : 	
 		[
 		"acetone cyanohydrin",


### PR DESCRIPTION
Some parsers fall over on this file due to an unnecessary non-printable character.

Removed with: `tr -cd '\11\12\15\40-\176'`
