### PR TITLE
Add Honeysuckle Weeks to British actors list

### DIFF
--- a/data/humans/britishActors.json
+++ b/data/humans/britishActors.json
@@ -699,6 +699,7 @@
     "James Fleet",
     "Trevor Peacock",
     "William Gaunt",
-    "Rowly Dennis"
+    "Rowly Dennis",
+    "Honeysuckle Weeks"
   ]
 }


### PR DESCRIPTION
Added Honeysuckle Weeks to the list of British actors because that is the best name ever given to a human being. She's in the BBC series "Foyle's War." For more info: http://en.wikipedia.org/wiki/Honeysuckle_Weeks
