### PR TITLE
Spelling fix (ma"am » ma'am)

### DIFF
--- a/data/words/nouns.json
+++ b/data/words/nouns.json
@@ -562,7 +562,7 @@
       "lookout",
       "lordship",
       "lustre",
-      "ma\"am",
+      "ma\'am",
       "machinery",
       "madness",
       "magnificence",


### PR DESCRIPTION
Source: http://www.merriam-webster.com/dictionary/ma'am