### PR TITLE
Spelling fix (ma"am » ma'am)

### DIFF
--- a/data/words/nouns.json
+++ b/data/words/nouns.json
@@ -562,7 +562,7 @@
       "lookout",
       "lordship",
       "lustre",
-      "ma\"am",
+      "ma'am",
       "machinery",
       "madness",
       "magnificence",


### PR DESCRIPTION
Replacement PR for https://github.com/dariusk/corpora/pull/153.

There's no need to escape the middle apostrophe, because double quotes are used for the string, not single quotes.