### PR TITLE
Use the newest node Travis CI supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.10
+  - 4.1
 sudo: false


### PR DESCRIPTION
Doesn't really affect build time or test results as far as I can see, but using this one does avoid a load of distracting warnings from 0.10:

```
npm WARN deprecated This version of npm lacks support for important features,
npm WARN deprecated such as scoped packages, offered by the primary npm
npm WARN deprecated registry. Consider upgrading to at least npm@2, if not the
npm WARN deprecated latest stable version. To upgrade to npm@2, run:
npm WARN deprecated 
npm WARN deprecated   npm -g install npm@latest-2
npm WARN deprecated 
npm WARN deprecated To upgrade to the latest stable version, run:
npm WARN deprecated 
npm WARN deprecated   npm -g install npm@latest
npm WARN deprecated 
npm WARN deprecated (Depending on how Node.js was installed on your system, you
npm WARN deprecated may need to prefix the preceding commands with `sudo`, or if
npm WARN deprecated on Windows, run them from an Administrator prompt.)
npm WARN deprecated 
npm WARN deprecated If you're running the version of npm bundled with
npm WARN deprecated Node.js 0.10 LTS, be aware that the next version of 0.10 LTS
npm WARN deprecated will be bundled with a version of npm@2, which has some small
npm WARN deprecated backwards-incompatible changes made to `npm run-script` and
npm WARN deprecated semver behavior.
```

https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Choosing-Node-versions-to-test-against
