### PR TITLE
lists for describing poetic meter

### DIFF
--- a/data/literature/metrical_feet_nouns.json
+++ b/data/literature/metrical_feet_nouns.json
@@ -1,0 +1,19 @@
+{
+  "description": "A list of types of metrical feet in poetry, as nouns.",
+  "metrical_foot_nouns": [
+    "pyrrhus",
+    "dibrach",
+    "iamb",
+    "trochee",
+    "spondee",
+    "tribrach",
+    "dactyl",
+    "amphibrach",
+    "anapest",
+    "bacchius",
+    "antibacchius",
+    "cretic",
+    "amphimacer",
+    "molossus"
+  ]
+}

--- a/data/literature/metrical_foot_adjectives.json
+++ b/data/literature/metrical_foot_adjectives.json
@@ -1,0 +1,19 @@
+{
+  "description": "A list of types of metrical feet in poetry, as adjectives.",
+  "metrical_foot_adjectives": [
+    "pyrrhic",
+    "dibrachic",
+    "iambic",
+    "trochaic",
+    "spondic",
+    "tribrachic",
+    "dactylic",
+    "amphibrachic",
+    "anapestic",
+    "bacchius",
+    "antibacchic",
+    "cretic",
+    "amphimacic",
+    "molossic"
+  ]
+}

--- a/data/literature/metrical_foot_counts.json
+++ b/data/literature/metrical_foot_counts.json
@@ -1,0 +1,13 @@
+{
+  "description": "A list of ways to describe the length of a poetic line in metrical feet.",
+  "metrical_line_lengths": [
+    "monometer",
+    "dimeter",
+    "trimeter",
+    "tetrameter",
+    "pentameter",
+    "hexameter",
+    "heptameter",
+    "octameter"
+  ]
+}


### PR DESCRIPTION
Lists for describing poetic meter.

Choose one term each from metrical_foot_adjectives.json and metrical_foot_counts.json to get phrases of the form "iambic pentameter," "trochaic tetrameter," etc.

Also included is metrical_foot_nouns.json, for when you want the noun form: "pyrrhus", "trochee", "spondee."