### PR TITLE
Pronouns

### DIFF
--- a/data/humans/thirdPersonPronouns.json
+++ b/data/humans/thirdPersonPronouns.json
@@ -1,4 +1,3 @@
-
 {
   "description": "Third person personal pronouns with case",
   "thirdPersonPronouns": [
@@ -8,6 +7,20 @@
       "dependentPossessive": "Eir",
       "independentPossessive": "Eirs",
       "reflexive": "Emself"
+    },
+    {
+      "subject": "bron",
+      "object": "bronc",
+      "dependentPossessive": "bronc",
+      "independentPossessive": "broncs",
+      "reflexive": "broncself"
+    },
+    {
+      "subject": "char",
+      "object": "char",
+      "dependentPossessive": "char",
+      "independentPossessive": "chars",
+      "reflexive": "charself"
     },
     {
       "subject": "che",
@@ -29,6 +42,13 @@
       "dependentPossessive": "cos",
       "independentPossessive": "co's",
       "reflexive": "coself"
+    },
+    {
+      "subject": "col",
+      "object": "col",
+      "dependentPossessive": "col",
+      "independentPossessive": "cols",
+      "reflexive": "colself"
     },
     {
       "subject": "e",
@@ -64,6 +84,27 @@
       "dependentPossessive": "feys",
       "independentPossessive": "feys",
       "reflexive": "feyself"
+    },
+    {
+      "subject": "fi",
+      "object": "fil",
+      "dependentPossessive": "fil",
+      "independentPossessive": "fils",
+      "reflexive": "filself"
+    },
+    {
+      "subject": "fo",
+      "object": "foa",
+      "dependentPossessive": "foal",
+      "independentPossessive": "foals",
+      "reflexive": "foself"
+    },
+    {
+      "subject": "ge",
+      "object": "gel",
+      "dependentPossessive": "gel",
+      "independentPossessive": "gels",
+      "reflexive": "gelself"
     },
     {
       "subject": "he",
@@ -108,6 +149,13 @@
       "reflexive": "kitself"
     },
     {
+      "subject": "mae",
+      "object": "mare",
+      "dependentPossessive": "mare",
+      "independentPossessive": "mares",
+      "reflexive": "mareself"
+    },
+    {
       "subject": "ne",
       "object": "nem",
       "dependentPossessive": "nir",
@@ -150,6 +198,13 @@
       "reflexive": "perself"
     },
     {
+      "subject": "po",
+      "object": "pon",
+      "dependentPossessive": "pos",
+      "independentPossessive": "pons",
+      "reflexive": "poself"
+    },
+    {
       "subject": "se",
       "object": "sim",
       "dependentPossessive": "ser",
@@ -176,6 +231,20 @@
       "dependentPossessive": "hir",
       "independentPossessive": "hirs",
       "reflexive": "hirself"
+    },
+    {
+      "subject": "sta",
+      "object": "stal",
+      "dependentPossessive": "stal",
+      "independentPossessive": "stals",
+      "reflexive": "stalself"
+    },
+    {
+      "subject": "ste",
+      "object": "step",
+      "dependentPossessive": "step",
+      "independentPossessive": "steps",
+      "reflexive": "stepself"
     },
     {
       "subject": "they",
@@ -288,6 +357,13 @@
       "dependentPossessive": "zer",
       "independentPossessive": "zers",
       "reflexive": "zemself"
+    },
+    {
+      "subject": "ze",
+      "object": "zeb",
+      "dependentPossessive": "zebr",
+      "independentPossessive": "zebrs",
+      "reflexive": "zebself"
     },
     {
       "subject": "ze",

--- a/data/humans/thirdPersonPronouns.json
+++ b/data/humans/thirdPersonPronouns.json
@@ -114,13 +114,6 @@
       "reflexive": "himself"
     },
     {
-      "subject": "he",
-      "object": "she",
-      "dependentPossessive": "it",
-      "independentPossessive": "they",
-      "reflexive": "and"
-    },
-    {
       "subject": "hu",
       "object": "hum",
       "dependentPossessive": "hus",

--- a/data/humans/thirdPersonPronouns.json
+++ b/data/humans/thirdPersonPronouns.json
@@ -1,0 +1,223 @@
+{
+  "description": "Third person personal pronouns with case",
+  "thirdPersonPronouns": [
+
+    {
+      "subject": "ze",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "ze",
+      "object": "zir",
+      "dependentPossessive": "zir",
+      "independentPossessive": "zirs",
+      "reflexive": "zirself"
+    },
+    {
+      "subject": "she",
+      "object": "her",
+      "dependentPossessive": "her",
+      "independentPossessive": "hers",
+      "reflexive": "herself"
+    },
+    {
+      "subject": "he",
+      "object": "him",
+      "dependentPossessive": "his",
+      "independentPossessive": "his",
+      "reflexive": "himself"
+    },
+    {
+      "subject": "they",
+      "object": "them",
+      "dependentPossessive": "their",
+      "independentPossessive": "theirs",
+      "reflexive": "themselves"
+    },
+    {
+      "subject": "they",
+      "object": "them",
+      "dependentPossessive": "their",
+      "independentPossessive": "theirs",
+      "reflexive": "themself"
+    },
+    {
+      "subject": "xey",
+      "object": "xem",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "sie",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "it",
+      "object": "it",
+      "dependentPossessive": "its",
+      "independentPossessive": "its",
+      "reflexive": "itself"
+    },
+    {
+      "subject": "ey",
+      "object": "em",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "eirself"
+    },
+    {
+      "subject": "e",
+      "object": "em",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "hu",
+      "object": "hum",
+      "dependentPossessive": "hus",
+      "independentPossessive": "hus",
+      "reflexive": "humself"
+    },
+    {
+      "subject": "peh",
+      "object": "pehm",
+      "dependentPossessive": "peh's",
+      "independentPossessive": "peh's",
+      "reflexive": "pehself"
+    },
+    {
+      "subject": "per",
+      "object": "per",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "perself"
+    },
+    {
+      "subject": "thon",
+      "object": "thon",
+      "dependentPossessive": "thons",
+      "independentPossessive": "thons",
+      "reflexive": "thonself"
+    },
+    {
+      "subject": "jee",
+      "object": "jem",
+      "dependentPossessive": "jeir",
+      "independentPossessive": "jeirs",
+      "reflexive": "jemself"
+    },
+    {
+      "subject": "ve",
+      "object": "ver",
+      "dependentPossessive": "vis",
+      "independentPossessive": "vis",
+      "reflexive": "verself"
+    },
+    {
+      "subject": "xe",
+      "object": "xem",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "zie",
+      "object": "zir",
+      "dependentPossessive": "zir",
+      "independentPossessive": "zirs",
+      "reflexive": "zirself"
+    },
+    {
+      "subject": "ze",
+      "object": "zem",
+      "dependentPossessive": "zes",
+      "independentPossessive": "zes",
+      "reflexive": "zirself"
+    },
+    {
+      "subject": "zie",
+      "object": "zem",
+      "dependentPossessive": "zes",
+      "independentPossessive": "zes",
+      "reflexive": "zirself"
+    },
+    {
+      "subject": "ze",
+      "object": "mer",
+      "dependentPossessive": "zer",
+      "independentPossessive": "zers",
+      "reflexive": "zemself"
+    },
+    {
+      "subject": "se",
+      "object": "sim",
+      "dependentPossessive": "ser",
+      "independentPossessive": "sers",
+      "reflexive": "serself"
+    },
+    {
+      "subject": "zme",
+      "object": "zmyr",
+      "dependentPossessive": "zmyr",
+      "independentPossessive": "zmyrs",
+      "reflexive": "zmyrself"
+    },
+    {
+      "subject": "ve",
+      "object": "vem",
+      "dependentPossessive": "vir",
+      "independentPossessive": "virs",
+      "reflexive": "vemself"
+    },
+    {
+      "subject": "zee",
+      "object": "zed",
+      "dependentPossessive": "zeta",
+      "independentPossessive": "zetas",
+      "reflexive": "zedself"
+    },
+    {
+      "subject": "fae",
+      "object": "faer",
+      "dependentPossessive": "faer",
+      "independentPossessive": "faers",
+      "reflexive": "faerself"
+    },
+    {
+      "subject": "zie",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "si",
+      "object": "hyr",
+      "dependentPossessive": "hyr",
+      "independentPossessive": "hyrs",
+      "reflexive": "hyrself"
+    },
+    {
+      "subject": "kit",
+      "object": "kit",
+      "dependentPossessive": "kits",
+      "independentPossessive": "kits",
+      "reflexive": "kitself"
+    },
+    {
+      "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nirs",
+      "reflexive": "nemself"
+    }
+  ]
+}

--- a/data/humans/thirdPersonPronouns.json
+++ b/data/humans/thirdPersonPronouns.json
@@ -1,76 +1,34 @@
+
 {
   "description": "Third person personal pronouns with case",
   "thirdPersonPronouns": [
-
     {
-      "subject": "ze",
-      "object": "hir",
-      "dependentPossessive": "hir",
-      "independentPossessive": "hirs",
-      "reflexive": "hirself"
+      "subject": "E",
+      "object": "Em",
+      "dependentPossessive": "Eir",
+      "independentPossessive": "Eirs",
+      "reflexive": "Emself"
     },
     {
-      "subject": "ze",
-      "object": "zir",
-      "dependentPossessive": "zir",
-      "independentPossessive": "zirs",
-      "reflexive": "zirself"
+      "subject": "che",
+      "object": "chim",
+      "dependentPossessive": "chis",
+      "independentPossessive": "chis",
+      "reflexive": "chimself"
     },
     {
-      "subject": "she",
-      "object": "her",
-      "dependentPossessive": "her",
-      "independentPossessive": "hers",
-      "reflexive": "herself"
+      "subject": "co",
+      "object": "co",
+      "dependentPossessive": "co's",
+      "independentPossessive": "co's",
+      "reflexive": "coself"
     },
     {
-      "subject": "he",
-      "object": "him",
-      "dependentPossessive": "his",
-      "independentPossessive": "his",
-      "reflexive": "himself"
-    },
-    {
-      "subject": "they",
-      "object": "them",
-      "dependentPossessive": "their",
-      "independentPossessive": "theirs",
-      "reflexive": "themselves"
-    },
-    {
-      "subject": "they",
-      "object": "them",
-      "dependentPossessive": "their",
-      "independentPossessive": "theirs",
-      "reflexive": "themself"
-    },
-    {
-      "subject": "xey",
-      "object": "xem",
-      "dependentPossessive": "xyr",
-      "independentPossessive": "xyrs",
-      "reflexive": "xemself"
-    },
-    {
-      "subject": "sie",
-      "object": "hir",
-      "dependentPossessive": "hir",
-      "independentPossessive": "hirs",
-      "reflexive": "hirself"
-    },
-    {
-      "subject": "it",
-      "object": "it",
-      "dependentPossessive": "its",
-      "independentPossessive": "its",
-      "reflexive": "itself"
-    },
-    {
-      "subject": "ey",
-      "object": "em",
-      "dependentPossessive": "eir",
-      "independentPossessive": "eirs",
-      "reflexive": "eirself"
+      "subject": "co",
+      "object": "co",
+      "dependentPossessive": "cos",
+      "independentPossessive": "co's",
+      "reflexive": "coself"
     },
     {
       "subject": "e",
@@ -80,11 +38,95 @@
       "reflexive": "emself"
     },
     {
+      "subject": "ey",
+      "object": "em",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "eirself"
+    },
+    {
+      "subject": "ey",
+      "object": "em",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "fae",
+      "object": "faer",
+      "dependentPossessive": "faer",
+      "independentPossessive": "faers",
+      "reflexive": "faerself"
+    },
+    {
+      "subject": "fey",
+      "object": "fey",
+      "dependentPossessive": "feys",
+      "independentPossessive": "feys",
+      "reflexive": "feyself"
+    },
+    {
+      "subject": "he",
+      "object": "him",
+      "dependentPossessive": "his",
+      "independentPossessive": "his",
+      "reflexive": "himself"
+    },
+    {
+      "subject": "he",
+      "object": "she",
+      "dependentPossessive": "it",
+      "independentPossessive": "they",
+      "reflexive": "and"
+    },
+    {
       "subject": "hu",
       "object": "hum",
       "dependentPossessive": "hus",
       "independentPossessive": "hus",
       "reflexive": "humself"
+    },
+    {
+      "subject": "it",
+      "object": "it",
+      "dependentPossessive": "its",
+      "independentPossessive": "its",
+      "reflexive": "itself"
+    },
+    {
+      "subject": "jee",
+      "object": "jem",
+      "dependentPossessive": "jeir",
+      "independentPossessive": "jeirs",
+      "reflexive": "jemself"
+    },
+    {
+      "subject": "kit",
+      "object": "kit",
+      "dependentPossessive": "kits",
+      "independentPossessive": "kits",
+      "reflexive": "kitself"
+    },
+    {
+      "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nirs",
+      "reflexive": "nemself"
+    },
+    {
+      "subject": "ne",
+      "object": "ner",
+      "dependentPossessive": "nis",
+      "independentPossessive": "nis",
+      "reflexive": "nemself"
+    },
+    {
+      "subject": "ou",
+      "object": "ou",
+      "dependentPossessive": "ous",
+      "independentPossessive": "ous",
+      "reflexive": "ouself"
     },
     {
       "subject": "peh",
@@ -101,6 +143,62 @@
       "reflexive": "perself"
     },
     {
+      "subject": "person",
+      "object": "per",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "perself"
+    },
+    {
+      "subject": "se",
+      "object": "sim",
+      "dependentPossessive": "ser",
+      "independentPossessive": "sers",
+      "reflexive": "serself"
+    },
+    {
+      "subject": "she",
+      "object": "her",
+      "dependentPossessive": "her",
+      "independentPossessive": "hers",
+      "reflexive": "herself"
+    },
+    {
+      "subject": "si",
+      "object": "hyr",
+      "dependentPossessive": "hyr",
+      "independentPossessive": "hyrs",
+      "reflexive": "hyrself"
+    },
+    {
+      "subject": "sie",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "they",
+      "object": "them",
+      "dependentPossessive": "their",
+      "independentPossessive": "theirs",
+      "reflexive": "themself"
+    },
+    {
+      "subject": "they",
+      "object": "them",
+      "dependentPossessive": "their",
+      "independentPossessive": "theirs",
+      "reflexive": "themselves"
+    },
+    {
+      "subject": "thon",
+      "object": "thon",
+      "dependentPossessive": "thons",
+      "independentPossessive": "thon's",
+      "reflexive": "thonself"
+    },
+    {
       "subject": "thon",
       "object": "thon",
       "dependentPossessive": "thons",
@@ -108,11 +206,11 @@
       "reflexive": "thonself"
     },
     {
-      "subject": "jee",
-      "object": "jem",
-      "dependentPossessive": "jeir",
-      "independentPossessive": "jeirs",
-      "reflexive": "jemself"
+      "subject": "ve",
+      "object": "vem",
+      "dependentPossessive": "vir",
+      "independentPossessive": "virs",
+      "reflexive": "vemself"
     },
     {
       "subject": "ve",
@@ -123,31 +221,66 @@
     },
     {
       "subject": "xe",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "xe",
       "object": "xem",
       "dependentPossessive": "xyr",
       "independentPossessive": "xyrs",
       "reflexive": "xemself"
     },
     {
-      "subject": "zie",
-      "object": "zir",
-      "dependentPossessive": "zir",
-      "independentPossessive": "zirs",
-      "reflexive": "zirself"
+      "subject": "xe",
+      "object": "xem",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xyrself"
+    },
+    {
+      "subject": "xe",
+      "object": "xir",
+      "dependentPossessive": "xir",
+      "independentPossessive": "xirs",
+      "reflexive": "xirself"
+    },
+    {
+      "subject": "xe",
+      "object": "xyr",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "xe",
+      "object": "xyr",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xyrself"
+    },
+    {
+      "subject": "xey",
+      "object": "xem",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xemself"
     },
     {
       "subject": "ze",
-      "object": "zem",
-      "dependentPossessive": "zes",
-      "independentPossessive": "zes",
-      "reflexive": "zirself"
+      "object": "em",
+      "dependentPossessive": "zeir",
+      "independentPossessive": "zeirs",
+      "reflexive": "zeirself"
     },
     {
-      "subject": "zie",
-      "object": "zem",
-      "dependentPossessive": "zes",
-      "independentPossessive": "zes",
-      "reflexive": "zirself"
+      "subject": "ze",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
     },
     {
       "subject": "ze",
@@ -157,25 +290,18 @@
       "reflexive": "zemself"
     },
     {
-      "subject": "se",
-      "object": "sim",
-      "dependentPossessive": "ser",
-      "independentPossessive": "sers",
-      "reflexive": "serself"
+      "subject": "ze",
+      "object": "zem",
+      "dependentPossessive": "zes",
+      "independentPossessive": "zes",
+      "reflexive": "zirself"
     },
     {
-      "subject": "zme",
-      "object": "zmyr",
-      "dependentPossessive": "zmyr",
-      "independentPossessive": "zmyrs",
-      "reflexive": "zmyrself"
-    },
-    {
-      "subject": "ve",
-      "object": "vem",
-      "dependentPossessive": "vir",
-      "independentPossessive": "virs",
-      "reflexive": "vemself"
+      "subject": "ze",
+      "object": "zir",
+      "dependentPossessive": "zir",
+      "independentPossessive": "zirs",
+      "reflexive": "zirself"
     },
     {
       "subject": "zee",
@@ -185,13 +311,6 @@
       "reflexive": "zedself"
     },
     {
-      "subject": "fae",
-      "object": "faer",
-      "dependentPossessive": "faer",
-      "independentPossessive": "faers",
-      "reflexive": "faerself"
-    },
-    {
       "subject": "zie",
       "object": "hir",
       "dependentPossessive": "hir",
@@ -199,25 +318,32 @@
       "reflexive": "hirself"
     },
     {
-      "subject": "si",
-      "object": "hyr",
-      "dependentPossessive": "hyr",
-      "independentPossessive": "hyrs",
-      "reflexive": "hyrself"
+      "subject": "zie",
+      "object": "zem",
+      "dependentPossessive": "zes",
+      "independentPossessive": "zes",
+      "reflexive": "zirself"
     },
     {
-      "subject": "kit",
-      "object": "kit",
-      "dependentPossessive": "kits",
-      "independentPossessive": "kits",
-      "reflexive": "kitself"
+      "subject": "zie",
+      "object": "zim",
+      "dependentPossessive": "zir",
+      "independentPossessive": "zirs",
+      "reflexive": "zirself"
     },
     {
-      "subject": "ne",
-      "object": "nem",
-      "dependentPossessive": "nir",
-      "independentPossessive": "nirs",
-      "reflexive": "nemself"
+      "subject": "zie",
+      "object": "zir",
+      "dependentPossessive": "zir",
+      "independentPossessive": "zirs",
+      "reflexive": "zirself"
+    },
+    {
+      "subject": "zme",
+      "object": "zmyr",
+      "dependentPossessive": "zmyr",
+      "independentPossessive": "zmyrs",
+      "reflexive": "zmyrself"
     }
   ]
 }


### PR DESCRIPTION
I've added a json file in humans/ containing third-person personal pronouns (she, they, he, zie, etc.). Each set includes all 5 cases used in English, annotated using the terminology used in [this table on Wikipedia](https://en.wikipedia.org/wiki/English_personal_pronouns#Basic).
They're all automatically parsed from [pronoun.is](http://pronoun.is), [nonbinary.org](http://nonbinary.org/wiki/Pronouns), and [ask a non-binary](http://askanonbinary.tumblr.com/pronouns). I've stuck to low-hanging fruit - pronoun sets that specify all 5 forms explicitly, and with a limited character set. There's room to add more if sets that only specify 3 or 4 pronouns can be correctly extended (preferably automatically) to the full form.