### PR TITLE
Large update to thirdPersonPronouns.json

### DIFF
--- a/data/humans/thirdPersonPronouns.json
+++ b/data/humans/thirdPersonPronouns.json
@@ -2,11 +2,893 @@
   "description": "Third person personal pronouns with case",
   "thirdPersonPronouns": [
     {
+      "subject": "'e",
+      "object": "'im",
+      "dependentPossessive": "'er",
+      "independentPossessive": "'ers",
+      "reflexive": "'imself"
+    },
+    {
+      "subject": "*e",
+      "object": "h*",
+      "dependentPossessive": "h*s",
+      "independentPossessive": "h*s",
+      "reflexive": "h*self"
+    },
+    {
+      "subject": "0",
+      "object": "0",
+      "dependentPossessive": "0s",
+      "independentPossessive": "0s",
+      "reflexive": "0self"
+    },
+    {
+      "subject": "000",
+      "object": "000",
+      "dependentPossessive": "000s",
+      "independentPossessive": "000s",
+      "reflexive": "000self"
+    },
+    {
+      "subject": "1",
+      "object": "1",
+      "dependentPossessive": "1s",
+      "independentPossessive": "1s",
+      "reflexive": "1self"
+    },
+    {
+      "subject": "2",
+      "object": "2",
+      "dependentPossessive": "2s",
+      "independentPossessive": "2s",
+      "reflexive": "2self"
+    },
+    {
+      "subject": "3",
+      "object": "3",
+      "dependentPossessive": "3s",
+      "independentPossessive": "3s",
+      "reflexive": "3self"
+    },
+    {
+      "subject": "4",
+      "object": "4",
+      "dependentPossessive": "4s",
+      "independentPossessive": "4s",
+      "reflexive": "4self"
+    },
+    {
+      "subject": "5",
+      "object": "5",
+      "dependentPossessive": "5s",
+      "independentPossessive": "5s",
+      "reflexive": "5self"
+    },
+    {
+      "subject": "6",
+      "object": "6",
+      "dependentPossessive": "6s",
+      "independentPossessive": "6s",
+      "reflexive": "6self"
+    },
+    {
+      "subject": "7",
+      "object": "7",
+      "dependentPossessive": "7s",
+      "independentPossessive": "7s",
+      "reflexive": "7self"
+    },
+    {
+      "subject": "8",
+      "object": "8",
+      "dependentPossessive": "8s",
+      "independentPossessive": "8s",
+      "reflexive": "8self"
+    },
+    {
+      "subject": "9",
+      "object": "9",
+      "dependentPossessive": "9s",
+      "independentPossessive": "9s",
+      "reflexive": "9self"
+    },
+    {
+      "subject": "?",
+      "object": "?s",
+      "dependentPossessive": "?s",
+      "independentPossessive": "?",
+      "reflexive": "?self"
+    },
+    {
       "subject": "E",
       "object": "Em",
       "dependentPossessive": "Eir",
       "independentPossessive": "Eirs",
       "reflexive": "Emself"
+    },
+    {
+      "subject": "_",
+      "object": "_s",
+      "dependentPossessive": "_s",
+      "independentPossessive": "_",
+      "reflexive": "_self"
+    },
+    {
+      "subject": "a",
+      "object": "a",
+      "dependentPossessive": "a’s",
+      "independentPossessive": "a’s",
+      "reflexive": "aself"
+    },
+    {
+      "subject": "a",
+      "object": "ac",
+      "dependentPossessive": "ux",
+      "independentPossessive": "rux",
+      "reflexive": "acruxself"
+    },
+    {
+      "subject": "a",
+      "object": "al",
+      "dependentPossessive": "ala",
+      "independentPossessive": "alaba",
+      "reflexive": "alabamaself"
+    },
+    {
+      "subject": "a",
+      "object": "an",
+      "dependentPossessive": "ant",
+      "independentPossessive": "ant",
+      "reflexive": "antself"
+    },
+    {
+      "subject": "a",
+      "object": "lan",
+      "dependentPossessive": "atla",
+      "independentPossessive": "atlan",
+      "reflexive": "atlantiself"
+    },
+    {
+      "subject": "a",
+      "object": "lan",
+      "dependentPossessive": "tic",
+      "independentPossessive": "antic",
+      "reflexive": "atlanticself"
+    },
+    {
+      "subject": "ada",
+      "object": "dar",
+      "dependentPossessive": "ara",
+      "independentPossessive": "dara",
+      "reflexive": "adaraself"
+    },
+    {
+      "subject": "ae",
+      "object": "aeg",
+      "dependentPossessive": "gea",
+      "independentPossessive": "gean",
+      "reflexive": "aegeanself"
+    },
+    {
+      "subject": "ae",
+      "object": "aem",
+      "dependentPossessive": "aer",
+      "independentPossessive": "aers",
+      "reflexive": "aemself"
+    },
+    {
+      "subject": "ae",
+      "object": "aer",
+      "dependentPossessive": "aer",
+      "independentPossessive": "aes",
+      "reflexive": "aeself"
+    },
+    {
+      "subject": "ae",
+      "object": "onium",
+      "dependentPossessive": "onis",
+      "independentPossessive": "onis",
+      "reflexive": "aeoniself"
+    },
+    {
+      "subject": "aer",
+      "object": "aer",
+      "dependentPossessive": "aer",
+      "independentPossessive": "aers",
+      "reflexive": "aerself"
+    },
+    {
+      "subject": "affo",
+      "object": "gato",
+      "dependentPossessive": "affs",
+      "independentPossessive": "affos",
+      "reflexive": "affoself"
+    },
+    {
+      "subject": "aga",
+      "object": "ve",
+      "dependentPossessive": "ves",
+      "independentPossessive": "ves",
+      "reflexive": "agaveself"
+    },
+    {
+      "subject": "al",
+      "object": "alph",
+      "dependentPossessive": "ala",
+      "independentPossessive": "alpha",
+      "reflexive": "alphaself"
+    },
+    {
+      "subject": "al",
+      "object": "alph",
+      "dependentPossessive": "alphys",
+      "independentPossessive": "alphys",
+      "reflexive": "alphyself"
+    },
+    {
+      "subject": "al",
+      "object": "alt",
+      "dependentPossessive": "ato",
+      "independentPossessive": "alto",
+      "reflexive": "altoself"
+    },
+    {
+      "subject": "al",
+      "object": "raune",
+      "dependentPossessive": "raus",
+      "independentPossessive": "raus",
+      "reflexive": "rauself"
+    },
+    {
+      "subject": "ala",
+      "object": "alum",
+      "dependentPossessive": "alis",
+      "independentPossessive": "alis",
+      "reflexive": "alumself"
+    },
+    {
+      "subject": "ali",
+      "object": "corn",
+      "dependentPossessive": "alis",
+      "independentPossessive": "alis",
+      "reflexive": "aliself"
+    },
+    {
+      "subject": "aloe",
+      "object": "loe",
+      "dependentPossessive": "loes",
+      "independentPossessive": "loes",
+      "reflexive": "aloeself"
+    },
+    {
+      "subject": "aloe",
+      "object": "vera",
+      "dependentPossessive": "ver",
+      "independentPossessive": "veras",
+      "reflexive": "aloeself"
+    },
+    {
+      "subject": "am",
+      "object": "am",
+      "dependentPossessive": "ams",
+      "independentPossessive": "ams",
+      "reflexive": "amself"
+    },
+    {
+      "subject": "am",
+      "object": "phip",
+      "dependentPossessive": "phir",
+      "independentPossessive": "phirs",
+      "reflexive": "phipself"
+    },
+    {
+      "subject": "ama",
+      "object": "amara",
+      "dependentPossessive": "amaran",
+      "independentPossessive": "amaranth",
+      "reflexive": "amaranself"
+    },
+    {
+      "subject": "amphip",
+      "object": "tere",
+      "dependentPossessive": "tere",
+      "independentPossessive": "teres",
+      "reflexive": "tereself"
+    },
+    {
+      "subject": "amu",
+      "object": "sen",
+      "dependentPossessive": "mun",
+      "independentPossessive": "mund",
+      "reflexive": "amundsenself"
+    },
+    {
+      "subject": "ao",
+      "object": "aos",
+      "dependentPossessive": "aos",
+      "independentPossessive": "ao",
+      "reflexive": "aoself"
+    },
+    {
+      "subject": "app",
+      "object": "apple",
+      "dependentPossessive": "apples",
+      "independentPossessive": "apples",
+      "reflexive": "appleself"
+    },
+    {
+      "subject": "apri",
+      "object": "cot",
+      "dependentPossessive": "apris",
+      "independentPossessive": "cots",
+      "reflexive": "apriself"
+    },
+    {
+      "subject": "ar",
+      "object": "argu",
+      "dependentPossessive": "ar",
+      "independentPossessive": "ars",
+      "reflexive": "arguself"
+    },
+    {
+      "subject": "ar",
+      "object": "aria",
+      "dependentPossessive": "rias",
+      "independentPossessive": "rias",
+      "reflexive": "ariaself"
+    },
+    {
+      "subject": "arach",
+      "object": "ne",
+      "dependentPossessive": "nes",
+      "independentPossessive": "nes",
+      "reflexive": "arachself"
+    },
+    {
+      "subject": "arr",
+      "object": "array",
+      "dependentPossessive": "arr",
+      "independentPossessive": "arrs",
+      "reflexive": "arrayself"
+    },
+    {
+      "subject": "art",
+      "object": "art",
+      "dependentPossessive": "arts",
+      "independentPossessive": "arts",
+      "reflexive": "artself"
+    },
+    {
+      "subject": "as",
+      "object": "asgore",
+      "dependentPossessive": "asgores",
+      "independentPossessive": "asgores",
+      "reflexive": "asgoreself"
+    },
+    {
+      "subject": "as",
+      "object": "asri",
+      "dependentPossessive": "asriels",
+      "independentPossessive": "asriels",
+      "reflexive": "asriself"
+    },
+    {
+      "subject": "auth",
+      "object": "auth",
+      "dependentPossessive": "auths",
+      "independentPossessive": "auths",
+      "reflexive": "authorself"
+    },
+    {
+      "subject": "av",
+      "object": "avo",
+      "dependentPossessive": "avs",
+      "independentPossessive": "avs",
+      "reflexive": "avself"
+    },
+    {
+      "subject": "axo",
+      "object": "ax",
+      "dependentPossessive": "lotl",
+      "independentPossessive": "olotl",
+      "reflexive": "axolotlself"
+    },
+    {
+      "subject": "ay",
+      "object": "em",
+      "dependentPossessive": "air",
+      "independentPossessive": "airs",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "b",
+      "object": "b",
+      "dependentPossessive": "b’s",
+      "independentPossessive": "b’s",
+      "reflexive": "bself"
+    },
+    {
+      "subject": "ba",
+      "object": "bak",
+      "dependentPossessive": "er",
+      "independentPossessive": "ker",
+      "reflexive": "bakerself"
+    },
+    {
+      "subject": "ba",
+      "object": "bal",
+      "dependentPossessive": "le",
+      "independentPossessive": "lear",
+      "reflexive": "balearicself"
+    },
+    {
+      "subject": "ba",
+      "object": "balan",
+      "dependentPossessive": "bala",
+      "independentPossessive": "balans",
+      "reflexive": "balanceself"
+    },
+    {
+      "subject": "ba",
+      "object": "ban",
+      "dependentPossessive": "da",
+      "independentPossessive": "anda",
+      "reflexive": "bandaself"
+    },
+    {
+      "subject": "ba",
+      "object": "bass",
+      "dependentPossessive": "bass",
+      "independentPossessive": "basses",
+      "reflexive": "basself"
+    },
+    {
+      "subject": "ba",
+      "object": "bat",
+      "dependentPossessive": "bats",
+      "independentPossessive": "bats",
+      "reflexive": "batself"
+    },
+    {
+      "subject": "ba",
+      "object": "ber",
+      "dependentPossessive": "brai",
+      "independentPossessive": "brain",
+      "reflexive": "brainself"
+    },
+    {
+      "subject": "ba",
+      "object": "bir",
+      "dependentPossessive": "brass",
+      "independentPossessive": "brass",
+      "reflexive": "brasself"
+    },
+    {
+      "subject": "ba",
+      "object": "ren",
+      "dependentPossessive": "bar",
+      "independentPossessive": "baren",
+      "reflexive": "barentsself"
+    },
+    {
+      "subject": "ba",
+      "object": "tic",
+      "dependentPossessive": "bal",
+      "independentPossessive": "balti",
+      "reflexive": "balticself"
+    },
+    {
+      "subject": "baklav",
+      "object": "baklava",
+      "dependentPossessive": "baklavs",
+      "independentPossessive": "baklavs",
+      "reflexive": "baklavaself"
+    },
+    {
+      "subject": "bal",
+      "object": "rog",
+      "dependentPossessive": "bals",
+      "independentPossessive": "rogs",
+      "reflexive": "balself"
+    },
+    {
+      "subject": "ball",
+      "object": "ballad",
+      "dependentPossessive": "lads",
+      "independentPossessive": "lads",
+      "reflexive": "balladself"
+    },
+    {
+      "subject": "bam",
+      "object": "bamb",
+      "dependentPossessive": "bambs",
+      "independentPossessive": "bambs",
+      "reflexive": "bambself"
+    },
+    {
+      "subject": "ban",
+      "object": "bana",
+      "dependentPossessive": "bans",
+      "independentPossessive": "bans",
+      "reflexive": "banself"
+    },
+    {
+      "subject": "bari",
+      "object": "tone",
+      "dependentPossessive": "bar",
+      "independentPossessive": "baris",
+      "reflexive": "bariself"
+    },
+    {
+      "subject": "barr",
+      "object": "rrel",
+      "dependentPossessive": "barr",
+      "independentPossessive": "barrs",
+      "reflexive": "barrself"
+    },
+    {
+      "subject": "basi",
+      "object": "lisk",
+      "dependentPossessive": "basis",
+      "independentPossessive": "lisks",
+      "reflexive": "basiself"
+    },
+    {
+      "subject": "bb",
+      "object": "bbcode",
+      "dependentPossessive": "bbs",
+      "independentPossessive": "bbcodes",
+      "reflexive": "bbcodeself"
+    },
+    {
+      "subject": "be",
+      "object": "am",
+      "dependentPossessive": "are",
+      "independentPossessive": "ares",
+      "reflexive": "amself"
+    },
+    {
+      "subject": "be",
+      "object": "am",
+      "dependentPossessive": "is",
+      "independentPossessive": "is",
+      "reflexive": "amself"
+    },
+    {
+      "subject": "be",
+      "object": "are",
+      "dependentPossessive": "ares",
+      "independentPossessive": "ares",
+      "reflexive": "areself"
+    },
+    {
+      "subject": "be",
+      "object": "are",
+      "dependentPossessive": "is",
+      "independentPossessive": "is",
+      "reflexive": "areself"
+    },
+    {
+      "subject": "be",
+      "object": "beach",
+      "dependentPossessive": "beas",
+      "independentPossessive": "beaches",
+      "reflexive": "beachself"
+    },
+    {
+      "subject": "be",
+      "object": "bec",
+      "dependentPossessive": "ux",
+      "independentPossessive": "rux",
+      "reflexive": "becruxself"
+    },
+    {
+      "subject": "be",
+      "object": "beech",
+      "dependentPossessive": "bies",
+      "independentPossessive": "beeches",
+      "reflexive": "beechself"
+    },
+    {
+      "subject": "be",
+      "object": "bel",
+      "dependentPossessive": "bells",
+      "independentPossessive": "bells",
+      "reflexive": "bellself"
+    },
+    {
+      "subject": "be",
+      "object": "bel",
+      "dependentPossessive": "ix",
+      "independentPossessive": "trix",
+      "reflexive": "bellatrixself"
+    },
+    {
+      "subject": "be",
+      "object": "ber",
+      "dependentPossessive": "bre",
+      "independentPossessive": "bres",
+      "reflexive": "brrself"
+    },
+    {
+      "subject": "be",
+      "object": "ber",
+      "dependentPossessive": "rin",
+      "independentPossessive": "erin",
+      "reflexive": "beringself"
+    },
+    {
+      "subject": "be",
+      "object": "bet",
+      "dependentPossessive": "beta",
+      "independentPossessive": "beta",
+      "reflexive": "betaself"
+    },
+    {
+      "subject": "be",
+      "object": "bet",
+      "dependentPossessive": "geu",
+      "independentPossessive": "geuse",
+      "reflexive": "betelgeuseself"
+    },
+    {
+      "subject": "bean",
+      "object": "paste",
+      "dependentPossessive": "pastes",
+      "independentPossessive": "pastes",
+      "reflexive": "pasteself"
+    },
+    {
+      "subject": "bear",
+      "object": "claw",
+      "dependentPossessive": "bear",
+      "independentPossessive": "bears",
+      "reflexive": "clawself"
+    },
+    {
+      "subject": "bee",
+      "object": "bee",
+      "dependentPossessive": "bees",
+      "independentPossessive": "bees",
+      "reflexive": "beeself"
+    },
+    {
+      "subject": "behe",
+      "object": "moth",
+      "dependentPossessive": "hes",
+      "independentPossessive": "hes",
+      "reflexive": "mothself"
+    },
+    {
+      "subject": "bene",
+      "object": "benet",
+      "dependentPossessive": "nas",
+      "independentPossessive": "nasch",
+      "reflexive": "benetnaschself"
+    },
+    {
+      "subject": "ber",
+      "object": "berr",
+      "dependentPossessive": "bers",
+      "independentPossessive": "bers",
+      "reflexive": "berryself"
+    },
+    {
+      "subject": "berli",
+      "object": "berliner",
+      "dependentPossessive": "berliner",
+      "independentPossessive": "beliners",
+      "reflexive": "berlinerself"
+    },
+    {
+      "subject": "bi",
+      "object": "bik",
+      "dependentPossessive": "cyl",
+      "independentPossessive": "cyc",
+      "reflexive": "bicycleself"
+    },
+    {
+      "subject": "bi",
+      "object": "biko",
+      "dependentPossessive": "kos",
+      "independentPossessive": "kos",
+      "reflexive": "bikoself"
+    },
+    {
+      "subject": "bi",
+      "object": "bingka",
+      "dependentPossessive": "bings",
+      "independentPossessive": "bings",
+      "reflexive": "bibingkaself"
+    },
+    {
+      "subject": "bi",
+      "object": "bio",
+      "dependentPossessive": "bo",
+      "independentPossessive": "biome",
+      "reflexive": "bioself"
+    },
+    {
+      "subject": "bi",
+      "object": "bir",
+      "dependentPossessive": "bier",
+      "independentPossessive": "biers",
+      "reflexive": "bierself"
+    },
+    {
+      "subject": "bi",
+      "object": "birch",
+      "dependentPossessive": "bir",
+      "independentPossessive": "birs",
+      "reflexive": "birchself"
+    },
+    {
+      "subject": "bi",
+      "object": "marck",
+      "dependentPossessive": "bis",
+      "independentPossessive": "bisma",
+      "reflexive": "bismarckself"
+    },
+    {
+      "subject": "bi",
+      "object": "muth",
+      "dependentPossessive": "bis",
+      "independentPossessive": "bismu",
+      "reflexive": "bismuthself"
+    },
+    {
+      "subject": "bi",
+      "object": "ob",
+      "dependentPossessive": "obs",
+      "independentPossessive": "obsid",
+      "reflexive": "obsidianself"
+    },
+    {
+      "subject": "bilo",
+      "object": "bilobilo",
+      "dependentPossessive": "bils",
+      "independentPossessive": "bils",
+      "reflexive": "bilobiloself"
+    },
+    {
+      "subject": "bis",
+      "object": "cuit",
+      "dependentPossessive": "cuits",
+      "independentPossessive": "cuits",
+      "reflexive": "biscuitself"
+    },
+    {
+      "subject": "bis",
+      "object": "scotti",
+      "dependentPossessive": "bis",
+      "independentPossessive": "bis",
+      "reflexive": "biscottiself"
+    },
+    {
+      "subject": "black",
+      "object": "berry",
+      "dependentPossessive": "berr",
+      "independentPossessive": "berrs",
+      "reflexive": "blackself"
+    },
+    {
+      "subject": "bloo",
+      "object": "blood",
+      "dependentPossessive": "blood",
+      "independentPossessive": "bloods",
+      "reflexive": "bloodself"
+    },
+    {
+      "subject": "bloo",
+      "object": "blook",
+      "dependentPossessive": "blooks",
+      "independentPossessive": "blooks",
+      "reflexive": "blookself"
+    },
+    {
+      "subject": "blu",
+      "object": "blue",
+      "dependentPossessive": "blues",
+      "independentPossessive": "blues",
+      "reflexive": "blueself"
+    },
+    {
+      "subject": "blue",
+      "object": "berry",
+      "dependentPossessive": "berr",
+      "independentPossessive": "berrs",
+      "reflexive": "blueself"
+    },
+    {
+      "subject": "bo",
+      "object": "bel",
+      "dependentPossessive": "oss",
+      "independentPossessive": "bloss",
+      "reflexive": "blossomself"
+    },
+    {
+      "subject": "bo",
+      "object": "bon",
+      "dependentPossessive": "bons",
+      "independentPossessive": "bons",
+      "reflexive": "boneself"
+    },
+    {
+      "subject": "bo",
+      "object": "bor",
+      "dependentPossessive": "eal",
+      "independentPossessive": "ealis",
+      "reflexive": "borealiself"
+    },
+    {
+      "subject": "bo",
+      "object": "both",
+      "dependentPossessive": "nin",
+      "independentPossessive": "nan",
+      "reflexive": "bothnianself"
+    },
+    {
+      "subject": "bo",
+      "object": "bron",
+      "dependentPossessive": "ron",
+      "independentPossessive": "rons",
+      "reflexive": "bronzeself"
+    },
+    {
+      "subject": "bo",
+      "object": "hol",
+      "dependentPossessive": "oho",
+      "independentPossessive": "ohol",
+      "reflexive": "boholself"
+    },
+    {
+      "subject": "boh",
+      "object": "ohb",
+      "dependentPossessive": "oha",
+      "independentPossessive": "ohai",
+      "reflexive": "bohaiself"
+    },
+    {
+      "subject": "bon",
+      "object": "bonbon",
+      "dependentPossessive": "bons",
+      "independentPossessive": "bonbons",
+      "reflexive": "bonself"
+    },
+    {
+      "subject": "boo",
+      "object": "boolean",
+      "dependentPossessive": "boos",
+      "independentPossessive": "bools",
+      "reflexive": "booself"
+    },
+    {
+      "subject": "boy",
+      "object": "sen",
+      "dependentPossessive": "boys",
+      "independentPossessive": "sens",
+      "reflexive": "boysenself"
+    },
+    {
+      "subject": "bree",
+      "object": "ber",
+      "dependentPossessive": "breeze",
+      "independentPossessive": "breezy",
+      "reflexive": "breezeself"
+    },
+    {
+      "subject": "brei",
+      "object": "brav",
+      "dependentPossessive": "bravir",
+      "independentPossessive": "bravi",
+      "reflexive": "braveself"
+    },
+    {
+      "subject": "bri",
+      "object": "brillia",
+      "dependentPossessive": "brill",
+      "independentPossessive": "brilli",
+      "reflexive": "brilliaself"
     },
     {
       "subject": "bron",
@@ -16,6 +898,440 @@
       "reflexive": "broncself"
     },
     {
+      "subject": "bru",
+      "object": "lee",
+      "dependentPossessive": "brus",
+      "independentPossessive": "brus",
+      "reflexive": "bruleeself"
+    },
+    {
+      "subject": "bu",
+      "object": "book",
+      "dependentPossessive": "books",
+      "independentPossessive": "books",
+      "reflexive": "bookself"
+    },
+    {
+      "subject": "bu",
+      "object": "ub",
+      "dependentPossessive": "bus",
+      "independentPossessive": "bus",
+      "reflexive": "busself"
+    },
+    {
+      "subject": "buch",
+      "object": "buchi",
+      "dependentPossessive": "buches",
+      "independentPossessive": "buches",
+      "reflexive": "buchiself"
+    },
+    {
+      "subject": "buck",
+      "object": "horn",
+      "dependentPossessive": "bucks",
+      "independentPossessive": "bucks",
+      "reflexive": "buckself"
+    },
+    {
+      "subject": "bunny",
+      "object": "ear",
+      "dependentPossessive": "ear",
+      "independentPossessive": "ears",
+      "reflexive": "bunnyearself"
+    },
+    {
+      "subject": "c",
+      "object": "c",
+      "dependentPossessive": "cs",
+      "independentPossessive": "cs",
+      "reflexive": "cself"
+    },
+    {
+      "subject": "c",
+      "object": "c",
+      "dependentPossessive": "c’s",
+      "independentPossessive": "c’s",
+      "reflexive": "cself"
+    },
+    {
+      "subject": "c",
+      "object": "c#",
+      "dependentPossessive": "c#s",
+      "independentPossessive": "c#s",
+      "reflexive": "c#self"
+    },
+    {
+      "subject": "c",
+      "object": "c++",
+      "dependentPossessive": "++",
+      "independentPossessive": "++s",
+      "reflexive": "c++self"
+    },
+    {
+      "subject": "c",
+      "object": "css",
+      "dependentPossessive": "cs",
+      "independentPossessive": "css",
+      "reflexive": "csself"
+    },
+    {
+      "subject": "ca",
+      "object": "arc",
+      "dependentPossessive": "arct",
+      "independentPossessive": "arcti",
+      "reflexive": "arcticself"
+    },
+    {
+      "subject": "ca",
+      "object": "cac",
+      "dependentPossessive": "cactu",
+      "independentPossessive": "cactus",
+      "reflexive": "cactuself"
+    },
+    {
+      "subject": "ca",
+      "object": "cal",
+      "dependentPossessive": "al",
+      "independentPossessive": "alm",
+      "reflexive": "calmself"
+    },
+    {
+      "subject": "ca",
+      "object": "cal",
+      "dependentPossessive": "cali",
+      "independentPossessive": "calif",
+      "reflexive": "californiaself"
+    },
+    {
+      "subject": "ca",
+      "object": "cal",
+      "dependentPossessive": "oud",
+      "independentPossessive": "cloud",
+      "reflexive": "cloudself"
+    },
+    {
+      "subject": "ca",
+      "object": "cam",
+      "dependentPossessive": "fla",
+      "independentPossessive": "flage",
+      "reflexive": "camouflageself"
+    },
+    {
+      "subject": "ca",
+      "object": "cam",
+      "dependentPossessive": "mel",
+      "independentPossessive": "mellia",
+      "reflexive": "camelliaself"
+    },
+    {
+      "subject": "ca",
+      "object": "cam",
+      "dependentPossessive": "tes",
+      "independentPossessive": "motes",
+      "reflexive": "camoteself"
+    },
+    {
+      "subject": "ca",
+      "object": "can",
+      "dependentPossessive": "anyo",
+      "independentPossessive": "anyon",
+      "reflexive": "canyonself"
+    },
+    {
+      "subject": "ca",
+      "object": "can",
+      "dependentPossessive": "cand",
+      "independentPossessive": "candles",
+      "reflexive": "candleself"
+    },
+    {
+      "subject": "ca",
+      "object": "cap",
+      "dependentPossessive": "pel",
+      "independentPossessive": "pella",
+      "reflexive": "capellaself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "cardin",
+      "independentPossessive": "cardi",
+      "reflexive": "cardinalself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "carna",
+      "independentPossessive": "carnati",
+      "reflexive": "carnationself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "caro",
+      "independentPossessive": "carol",
+      "reflexive": "carolself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "cro",
+      "independentPossessive": "cryo",
+      "reflexive": "cryoself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "ibb",
+      "independentPossessive": "ibbea",
+      "reflexive": "caribbeanself"
+    },
+    {
+      "subject": "ca",
+      "object": "car",
+      "dependentPossessive": "rol",
+      "independentPossessive": "rolin",
+      "reflexive": "carolinaself"
+    },
+    {
+      "subject": "ca",
+      "object": "cas",
+      "dependentPossessive": "tor",
+      "independentPossessive": "astor",
+      "reflexive": "castorself"
+    },
+    {
+      "subject": "ca",
+      "object": "catta",
+      "dependentPossessive": "cat",
+      "independentPossessive": "cattai",
+      "reflexive": "cattailself"
+    },
+    {
+      "subject": "ca",
+      "object": "dence",
+      "dependentPossessive": "dence",
+      "independentPossessive": "dences",
+      "reflexive": "cadenceself"
+    },
+    {
+      "subject": "ca",
+      "object": "denza",
+      "dependentPossessive": "denz",
+      "independentPossessive": "denz",
+      "reflexive": "denzaself"
+    },
+    {
+      "subject": "ca",
+      "object": "non",
+      "dependentPossessive": "nons",
+      "independentPossessive": "nons",
+      "reflexive": "canonself"
+    },
+    {
+      "subject": "ca",
+      "object": "pian",
+      "dependentPossessive": "cas",
+      "independentPossessive": "caspi",
+      "reflexive": "caspianself"
+    },
+    {
+      "subject": "ca",
+      "object": "tab",
+      "dependentPossessive": "ric",
+      "independentPossessive": "abric",
+      "reflexive": "cantabricself"
+    },
+    {
+      "subject": "ca",
+      "object": "uc",
+      "dependentPossessive": "yuc",
+      "independentPossessive": "ucca",
+      "reflexive": "yuccaself"
+    },
+    {
+      "subject": "cacta",
+      "object": "ceae",
+      "dependentPossessive": "ceaes",
+      "independentPossessive": "caeas",
+      "reflexive": "cactaself"
+    },
+    {
+      "subject": "cake",
+      "object": "roll",
+      "dependentPossessive": "rolls",
+      "independentPossessive": "rolls",
+      "reflexive": "cakerollself"
+    },
+    {
+      "subject": "cand",
+      "object": "candied",
+      "dependentPossessive": "cands",
+      "independentPossessive": "cands",
+      "reflexive": "candself"
+    },
+    {
+      "subject": "cand",
+      "object": "candy",
+      "dependentPossessive": "cands",
+      "independentPossessive": "cands",
+      "reflexive": "candself"
+    },
+    {
+      "subject": "canta",
+      "object": "bile",
+      "dependentPossessive": "biles",
+      "independentPossessive": "biles",
+      "reflexive": "cantaself"
+    },
+    {
+      "subject": "canta",
+      "object": "loupe",
+      "dependentPossessive": "loupes",
+      "independentPossessive": "loupes",
+      "reflexive": "cantaself"
+    },
+    {
+      "subject": "canta",
+      "object": "ta",
+      "dependentPossessive": "tas",
+      "independentPossessive": "tas",
+      "reflexive": "cantaself"
+    },
+    {
+      "subject": "canti",
+      "object": "cle",
+      "dependentPossessive": "cles",
+      "independentPossessive": "cles",
+      "reflexive": "cantiself"
+    },
+    {
+      "subject": "car",
+      "object": "don",
+      "dependentPossessive": "car",
+      "independentPossessive": "dons",
+      "reflexive": "cardonself"
+    },
+    {
+      "subject": "cara",
+      "object": "mel",
+      "dependentPossessive": "mels",
+      "independentPossessive": "mels",
+      "reflexive": "caraself"
+    },
+    {
+      "subject": "cava",
+      "object": "tina",
+      "dependentPossessive": "cavas",
+      "independentPossessive": "cavas",
+      "reflexive": "cavaself"
+    },
+    {
+      "subject": "ce",
+      "object": "cel",
+      "dependentPossessive": "cele",
+      "independentPossessive": "celebra",
+      "reflexive": "celebraself"
+    },
+    {
+      "subject": "ce",
+      "object": "cem",
+      "dependentPossessive": "cer",
+      "independentPossessive": "cers",
+      "reflexive": "cemself"
+    },
+    {
+      "subject": "ce",
+      "object": "cem",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "ce",
+      "object": "cer",
+      "dependentPossessive": "bel",
+      "independentPossessive": "bellum",
+      "reflexive": "cereself"
+    },
+    {
+      "subject": "ce",
+      "object": "cer",
+      "dependentPossessive": "ces",
+      "independentPossessive": "ces",
+      "reflexive": "ceself"
+    },
+    {
+      "subject": "ce",
+      "object": "cer",
+      "dependentPossessive": "ra",
+      "independentPossessive": "ram",
+      "reflexive": "ceramself"
+    },
+    {
+      "subject": "ce",
+      "object": "cerb",
+      "dependentPossessive": "cer",
+      "independentPossessive": "cers",
+      "reflexive": "cerself"
+    },
+    {
+      "subject": "ce",
+      "object": "cim",
+      "dependentPossessive": "cir",
+      "independentPossessive": "cirs",
+      "reflexive": "cirself"
+    },
+    {
+      "subject": "cen",
+      "object": "taur",
+      "dependentPossessive": "taur",
+      "independentPossessive": "taurs",
+      "reflexive": "cenself"
+    },
+    {
+      "subject": "cer",
+      "object": "berus",
+      "dependentPossessive": "berus",
+      "independentPossessive": "berus",
+      "reflexive": "cerself"
+    },
+    {
+      "subject": "cha",
+      "object": "cha",
+      "dependentPossessive": "chal",
+      "independentPossessive": "chalks",
+      "reflexive": "chalkself"
+    },
+    {
+      "subject": "cha",
+      "object": "cham",
+      "dependentPossessive": "chamel",
+      "independentPossessive": "chameleo",
+      "reflexive": "chameleoself"
+    },
+    {
+      "subject": "cha",
+      "object": "chan",
+      "dependentPossessive": "chas",
+      "independentPossessive": "chance",
+      "reflexive": "chanceself"
+    },
+    {
+      "subject": "cha",
+      "object": "chant",
+      "dependentPossessive": "chants",
+      "independentPossessive": "chants",
+      "reflexive": "chantself"
+    },
+    {
+      "subject": "cha",
+      "object": "chao",
+      "dependentPossessive": "chaos",
+      "independentPossessive": "chaos",
+      "reflexive": "chaosself"
+    },
+    {
       "subject": "char",
       "object": "char",
       "dependentPossessive": "char",
@@ -23,11 +1339,249 @@
       "reflexive": "charself"
     },
     {
+      "subject": "char",
+      "object": "chara",
+      "dependentPossessive": "charas",
+      "independentPossessive": "charas",
+      "reflexive": "charaself"
+    },
+    {
+      "subject": "chay",
+      "object": "chain",
+      "dependentPossessive": "chains",
+      "independentPossessive": "chains",
+      "reflexive": "chainself"
+    },
+    {
+      "subject": "che",
+      "object": "ach",
+      "dependentPossessive": "nar",
+      "independentPossessive": "ernar",
+      "reflexive": "achernarself"
+    },
+    {
+      "subject": "che",
+      "object": "chev",
+      "dependentPossessive": "chevs",
+      "independentPossessive": "chevs",
+      "reflexive": "chevself"
+    },
+    {
       "subject": "che",
       "object": "chim",
       "dependentPossessive": "chis",
       "independentPossessive": "chis",
       "reflexive": "chimself"
+    },
+    {
+      "subject": "che",
+      "object": "hap",
+      "dependentPossessive": "han",
+      "independentPossessive": "hans",
+      "reflexive": "hapself"
+    },
+    {
+      "subject": "che",
+      "object": "vil",
+      "dependentPossessive": "cher",
+      "independentPossessive": "cher",
+      "reflexive": "chervilself"
+    },
+    {
+      "subject": "cheese",
+      "object": "cake",
+      "dependentPossessive": "cheese",
+      "independentPossessive": "cakes",
+      "reflexive": "cheesecakeself"
+    },
+    {
+      "subject": "cherr",
+      "object": "cherr",
+      "dependentPossessive": "cherrs",
+      "independentPossessive": "cherrs",
+      "reflexive": "cherryself"
+    },
+    {
+      "subject": "chi",
+      "object": "ain",
+      "dependentPossessive": "anci",
+      "independentPossessive": "ancien",
+      "reflexive": "ancientself"
+    },
+    {
+      "subject": "chi",
+      "object": "chic",
+      "dependentPossessive": "dee",
+      "independentPossessive": "kadee",
+      "reflexive": "chickadeeself"
+    },
+    {
+      "subject": "chi",
+      "object": "chic",
+      "dependentPossessive": "ken",
+      "independentPossessive": "icken",
+      "reflexive": "chickenself"
+    },
+    {
+      "subject": "chi",
+      "object": "chim",
+      "dependentPossessive": "chis",
+      "independentPossessive": "chis",
+      "reflexive": "chiself"
+    },
+    {
+      "subject": "chi",
+      "object": "chiv",
+      "dependentPossessive": "chives",
+      "independentPossessive": "chive",
+      "reflexive": "chiveself"
+    },
+    {
+      "subject": "chi",
+      "object": "maera",
+      "dependentPossessive": "maer",
+      "independentPossessive": "maers",
+      "reflexive": "chimaeraself"
+    },
+    {
+      "subject": "chi",
+      "object": "meira",
+      "dependentPossessive": "meir",
+      "independentPossessive": "meirs",
+      "reflexive": "chimeiraself"
+    },
+    {
+      "subject": "chi",
+      "object": "mera",
+      "dependentPossessive": "mer",
+      "independentPossessive": "mers",
+      "reflexive": "chimeraself"
+    },
+    {
+      "subject": "cho",
+      "object": "choc",
+      "dependentPossessive": "chocol",
+      "independentPossessive": "choco",
+      "reflexive": "chocoself"
+    },
+    {
+      "subject": "cho",
+      "object": "choir",
+      "dependentPossessive": "chi",
+      "independentPossessive": "choi",
+      "reflexive": "choirself"
+    },
+    {
+      "subject": "choc",
+      "object": "choco",
+      "dependentPossessive": "chocs",
+      "independentPossessive": "chocos",
+      "reflexive": "chocoself"
+    },
+    {
+      "subject": "chor",
+      "object": "rale",
+      "dependentPossessive": "chor",
+      "independentPossessive": "chors",
+      "reflexive": "choraleself"
+    },
+    {
+      "subject": "chu",
+      "object": "chuk",
+      "dependentPossessive": "chi",
+      "independentPossessive": "ukchi",
+      "reflexive": "chukchiself"
+    },
+    {
+      "subject": "ci",
+      "object": "cim",
+      "dependentPossessive": "cir",
+      "independentPossessive": "cirs",
+      "reflexive": "cimself"
+    },
+    {
+      "subject": "ci",
+      "object": "cit",
+      "dependentPossessive": "citri",
+      "independentPossessive": "citrine",
+      "reflexive": "citrineself"
+    },
+    {
+      "subject": "ci",
+      "object": "cit",
+      "dependentPossessive": "citru",
+      "independentPossessive": "citrus",
+      "reflexive": "citruself"
+    },
+    {
+      "subject": "ci",
+      "object": "lan",
+      "dependentPossessive": "cil",
+      "independentPossessive": "cilan",
+      "reflexive": "cilanself"
+    },
+    {
+      "subject": "cii",
+      "object": "ciir",
+      "dependentPossessive": "ciir",
+      "independentPossessive": "ciirs",
+      "reflexive": "ciirself"
+    },
+    {
+      "subject": "cla",
+      "object": "class",
+      "dependentPossessive": "clas",
+      "independentPossessive": "class",
+      "reflexive": "clasself"
+    },
+    {
+      "subject": "cla",
+      "object": "sic",
+      "dependentPossessive": "las",
+      "independentPossessive": "clas",
+      "reflexive": "classicself"
+    },
+    {
+      "subject": "claret",
+      "object": "cup",
+      "dependentPossessive": "clar",
+      "independentPossessive": "clarets",
+      "reflexive": "claretself"
+    },
+    {
+      "subject": "cle",
+      "object": "clef",
+      "dependentPossessive": "clefs",
+      "independentPossessive": "clefs",
+      "reflexive": "clefself"
+    },
+    {
+      "subject": "clemen",
+      "object": "tine",
+      "dependentPossessive": "tines",
+      "independentPossessive": "tines",
+      "reflexive": "tineself"
+    },
+    {
+      "subject": "cli",
+      "object": "kal",
+      "dependentPossessive": "iff",
+      "independentPossessive": "liff",
+      "reflexive": "cliffself"
+    },
+    {
+      "subject": "cli",
+      "object": "per",
+      "dependentPossessive": "ip",
+      "independentPossessive": "ipre",
+      "reflexive": "clipperself"
+    },
+    {
+      "subject": "clo",
+      "object": "clover",
+      "dependentPossessive": "clov",
+      "independentPossessive": "clovs",
+      "reflexive": "cloverself"
     },
     {
       "subject": "co",
@@ -44,6 +1598,125 @@
       "reflexive": "coself"
     },
     {
+      "subject": "co",
+      "object": "coa",
+      "dependentPossessive": "cos",
+      "independentPossessive": "coas",
+      "reflexive": "cocoaself"
+    },
+    {
+      "subject": "co",
+      "object": "cobe",
+      "dependentPossessive": "coba",
+      "independentPossessive": "cobal",
+      "reflexive": "cobaltself"
+    },
+    {
+      "subject": "co",
+      "object": "coda",
+      "dependentPossessive": "cos",
+      "independentPossessive": "cos",
+      "reflexive": "coself"
+    },
+    {
+      "subject": "co",
+      "object": "code",
+      "dependentPossessive": "cos",
+      "independentPossessive": "codes",
+      "reflexive": "codeself"
+    },
+    {
+      "subject": "co",
+      "object": "col",
+      "dependentPossessive": "colo",
+      "independentPossessive": "color",
+      "reflexive": "colorself"
+    },
+    {
+      "subject": "co",
+      "object": "col",
+      "dependentPossessive": "colo",
+      "independentPossessive": "colora",
+      "reflexive": "coloradoself"
+    },
+    {
+      "subject": "co",
+      "object": "con",
+      "dependentPossessive": "cons",
+      "independentPossessive": "const",
+      "reflexive": "constellself"
+    },
+    {
+      "subject": "co",
+      "object": "confect",
+      "dependentPossessive": "fects",
+      "independentPossessive": "fects",
+      "reflexive": "confectself"
+    },
+    {
+      "subject": "co",
+      "object": "cont",
+      "dependentPossessive": "ten",
+      "independentPossessive": "onten",
+      "reflexive": "contentself"
+    },
+    {
+      "subject": "co",
+      "object": "copy",
+      "dependentPossessive": "cos",
+      "independentPossessive": "copys",
+      "reflexive": "copyself"
+    },
+    {
+      "subject": "co",
+      "object": "cor",
+      "dependentPossessive": "cora",
+      "independentPossessive": "coral",
+      "reflexive": "coralself"
+    },
+    {
+      "subject": "co",
+      "object": "cot",
+      "dependentPossessive": "coa",
+      "independentPossessive": "coas",
+      "reflexive": "coastself"
+    },
+    {
+      "subject": "co",
+      "object": "cot",
+      "dependentPossessive": "ton",
+      "independentPossessive": "otton",
+      "reflexive": "cottonself"
+    },
+    {
+      "subject": "co",
+      "object": "der",
+      "dependentPossessive": "cor",
+      "independentPossessive": "cori",
+      "reflexive": "corself"
+    },
+    {
+      "subject": "co",
+      "object": "lum",
+      "dependentPossessive": "bi",
+      "independentPossessive": "bine",
+      "reflexive": "columbineself"
+    },
+    {
+      "subject": "coa",
+      "object": "tl",
+      "dependentPossessive": "coas",
+      "independentPossessive": "coas",
+      "reflexive": "coaself"
+    },
+    {
+      "subject": "cocka",
+      "object": "trice",
+      "dependentPossessive": "trices",
+      "independentPossessive": "trices",
+      "reflexive": "triceself"
+    },
+    {
       "subject": "col",
       "object": "col",
       "dependentPossessive": "col",
@@ -51,11 +1724,802 @@
       "reflexive": "colself"
     },
     {
+      "subject": "com",
+      "object": "com",
+      "dependentPossessive": "comet",
+      "independentPossessive": "comets",
+      "reflexive": "comself"
+    },
+    {
+      "subject": "con",
+      "object": "certo",
+      "dependentPossessive": "cers",
+      "independentPossessive": "cers",
+      "reflexive": "certoself"
+    },
+    {
+      "subject": "conti",
+      "object": "nuo",
+      "dependentPossessive": "nuos",
+      "independentPossessive": "nuos",
+      "reflexive": "contiself"
+    },
+    {
+      "subject": "contra",
+      "object": "alto",
+      "dependentPossessive": "altos",
+      "independentPossessive": "altos",
+      "reflexive": "contraself"
+    },
+    {
+      "subject": "cot",
+      "object": "cot",
+      "dependentPossessive": "cots",
+      "independentPossessive": "cots",
+      "reflexive": "cotself"
+    },
+    {
+      "subject": "cotton",
+      "object": "candy",
+      "dependentPossessive": "candies",
+      "independentPossessive": "candies",
+      "reflexive": "cottonself"
+    },
+    {
+      "subject": "cour",
+      "object": "ante",
+      "dependentPossessive": "cour",
+      "independentPossessive": "cours",
+      "reflexive": "ranteself"
+    },
+    {
+      "subject": "couture",
+      "object": "couture",
+      "dependentPossessive": "coutures",
+      "independentPossessive": "coutures",
+      "reflexive": "coutureself"
+    },
+    {
+      "subject": "cra",
+      "object": "cor",
+      "dependentPossessive": "ab",
+      "independentPossessive": "rab",
+      "reflexive": "crabself"
+    },
+    {
+      "subject": "cra",
+      "object": "cran",
+      "dependentPossessive": "cran",
+      "independentPossessive": "crane",
+      "reflexive": "craneself"
+    },
+    {
+      "subject": "crai",
+      "object": "sin",
+      "dependentPossessive": "crais",
+      "independentPossessive": "sins",
+      "reflexive": "craiself"
+    },
+    {
+      "subject": "cran",
+      "object": "berry",
+      "dependentPossessive": "berr",
+      "independentPossessive": "berrs",
+      "reflexive": "cranself"
+    },
+    {
+      "subject": "cre",
+      "object": "creme",
+      "dependentPossessive": "cres",
+      "independentPossessive": "cremes",
+      "reflexive": "cremeself"
+    },
+    {
+      "subject": "cream",
+      "object": "puff",
+      "dependentPossessive": "puffs",
+      "independentPossessive": "puffs",
+      "reflexive": "creampuffself"
+    },
+    {
+      "subject": "cri",
+      "object": "crim",
+      "dependentPossessive": "cris",
+      "independentPossessive": "crims",
+      "reflexive": "crimsonself"
+    },
+    {
+      "subject": "cri",
+      "object": "ker",
+      "dependentPossessive": "crys",
+      "independentPossessive": "cryst",
+      "reflexive": "crystalself"
+    },
+    {
+      "subject": "cri",
+      "object": "ket",
+      "dependentPossessive": "ic",
+      "independentPossessive": "cric",
+      "reflexive": "cricketself"
+    },
+    {
+      "subject": "cro",
+      "object": "cor",
+      "dependentPossessive": "cos",
+      "independentPossessive": "cros",
+      "reflexive": "crowself"
+    },
+    {
+      "subject": "cro",
+      "object": "croc",
+      "dependentPossessive": "dil",
+      "independentPossessive": "dile",
+      "reflexive": "crocodileself"
+    },
+    {
+      "subject": "cru",
+      "object": "crumble",
+      "dependentPossessive": "crumbs",
+      "independentPossessive": "crumbs",
+      "reflexive": "crumbleself"
+    },
+    {
+      "subject": "cu",
+      "object": "cu",
+      "dependentPossessive": "cube",
+      "independentPossessive": "cubes",
+      "reflexive": "cubeself"
+    },
+    {
+      "subject": "cu",
+      "object": "cur",
+      "dependentPossessive": "curi",
+      "independentPossessive": "curious",
+      "reflexive": "curiouself"
+    },
+    {
+      "subject": "cur",
+      "object": "rant",
+      "dependentPossessive": "curr",
+      "independentPossessive": "currs",
+      "reflexive": "currself"
+    },
+    {
+      "subject": "cute",
+      "object": "cute",
+      "dependentPossessive": "cutes",
+      "independentPossessive": "cutes",
+      "reflexive": "cuteself"
+    },
+    {
+      "subject": "cv",
+      "object": "cvs",
+      "dependentPossessive": "cvs",
+      "independentPossessive": "cvs",
+      "reflexive": "cvself"
+    },
+    {
+      "subject": "cy",
+      "object": "clops",
+      "dependentPossessive": "cyr",
+      "independentPossessive": "cyrs",
+      "reflexive": "cyself"
+    },
+    {
+      "subject": "cy",
+      "object": "clops",
+      "dependentPossessive": "cys",
+      "independentPossessive": "cyrs",
+      "reflexive": "cyself"
+    },
+    {
+      "subject": "cy",
+      "object": "cyan",
+      "dependentPossessive": "ayn",
+      "independentPossessive": "yan",
+      "reflexive": "cyanself"
+    },
+    {
+      "subject": "d",
+      "object": "d",
+      "dependentPossessive": "d’s",
+      "independentPossessive": "d’s",
+      "reflexive": "dself"
+    },
+    {
+      "subject": "d'u",
+      "object": "d'ur",
+      "dependentPossessive": "vi",
+      "independentPossessive": "vil",
+      "reflexive": "d'urvilleself"
+    },
+    {
+      "subject": "da",
+      "object": "ald",
+      "dependentPossessive": "deb",
+      "independentPossessive": "debar",
+      "reflexive": "aldebaranself"
+    },
+    {
+      "subject": "da",
+      "object": "an",
+      "dependentPossessive": "anda",
+      "independentPossessive": "andam",
+      "reflexive": "andamanself"
+    },
+    {
+      "subject": "da",
+      "object": "dak",
+      "dependentPossessive": "kot",
+      "independentPossessive": "kota",
+      "reflexive": "dakotaself"
+    },
+    {
+      "subject": "da",
+      "object": "data",
+      "dependentPossessive": "das",
+      "independentPossessive": "datas",
+      "reflexive": "dataself"
+    },
+    {
+      "subject": "da",
+      "object": "dav",
+      "dependentPossessive": "vi",
+      "independentPossessive": "vis",
+      "reflexive": "daviself"
+    },
+    {
+      "subject": "da",
+      "object": "daw",
+      "dependentPossessive": "dawn",
+      "independentPossessive": "dawns",
+      "reflexive": "dawnself"
+    },
+    {
+      "subject": "da",
+      "object": "dusk",
+      "dependentPossessive": "dus",
+      "independentPossessive": "dus",
+      "reflexive": "duskself"
+    },
+    {
+      "subject": "da",
+      "object": "id",
+      "dependentPossessive": "ida",
+      "independentPossessive": "ido",
+      "reflexive": "idahoself"
+    },
+    {
+      "subject": "dai",
+      "object": "daisy",
+      "dependentPossessive": "dais",
+      "independentPossessive": "dais",
+      "reflexive": "daisyself"
+    },
+    {
+      "subject": "dan",
+      "object": "dango",
+      "dependentPossessive": "dans",
+      "independentPossessive": "dans",
+      "reflexive": "dangoself"
+    },
+    {
+      "subject": "day",
+      "object": "day",
+      "dependentPossessive": "days",
+      "independentPossessive": "days",
+      "reflexive": "dayself"
+    },
+    {
+      "subject": "de",
+      "object": "dea",
+      "dependentPossessive": "dath",
+      "independentPossessive": "death",
+      "reflexive": "deathself"
+    },
+    {
+      "subject": "de",
+      "object": "dec",
+      "dependentPossessive": "deca",
+      "independentPossessive": "decad",
+      "reflexive": "decadself"
+    },
+    {
+      "subject": "de",
+      "object": "del",
+      "dependentPossessive": "awa",
+      "independentPossessive": "awar",
+      "reflexive": "delawareself"
+    },
+    {
+      "subject": "de",
+      "object": "dem",
+      "dependentPossessive": "deii",
+      "independentPossessive": "demi",
+      "reflexive": "demiself"
+    },
+    {
+      "subject": "de",
+      "object": "den",
+      "dependentPossessive": "neb",
+      "independentPossessive": "deneb",
+      "reflexive": "denebself"
+    },
+    {
+      "subject": "de",
+      "object": "denim",
+      "dependentPossessive": "den",
+      "independentPossessive": "deni",
+      "reflexive": "denimself"
+    },
+    {
+      "subject": "de",
+      "object": "der",
+      "dependentPossessive": "ders",
+      "independentPossessive": "derse",
+      "reflexive": "derself"
+    },
+    {
+      "subject": "de",
+      "object": "des",
+      "dependentPossessive": "der",
+      "independentPossessive": "deser",
+      "reflexive": "desertself"
+    },
+    {
+      "subject": "de",
+      "object": "dest",
+      "dependentPossessive": "des",
+      "independentPossessive": "des",
+      "reflexive": "destself"
+    },
+    {
+      "subject": "deca",
+      "object": "dent",
+      "dependentPossessive": "decas",
+      "independentPossessive": "decas",
+      "reflexive": "decaself"
+    },
+    {
+      "subject": "des",
+      "object": "sert",
+      "dependentPossessive": "ser",
+      "independentPossessive": "serts",
+      "reflexive": "dessertself"
+    },
+    {
+      "subject": "dey",
+      "object": "de",
+      "dependentPossessive": "deir",
+      "independentPossessive": "deirs",
+      "reflexive": "deyself"
+    },
+    {
+      "subject": "di",
+      "object": "der",
+      "dependentPossessive": "dirt",
+      "independentPossessive": "dirts",
+      "reflexive": "dirtself"
+    },
+    {
+      "subject": "di",
+      "object": "di",
+      "dependentPossessive": "dice",
+      "independentPossessive": "dice",
+      "reflexive": "diceself"
+    },
+    {
+      "subject": "di",
+      "object": "dif",
+      "dependentPossessive": "dis",
+      "independentPossessive": "difs",
+      "reflexive": "difself"
+    },
+    {
+      "subject": "di",
+      "object": "dip",
+      "dependentPossessive": "dipper",
+      "independentPossessive": "dippers",
+      "reflexive": "dipperself"
+    },
+    {
+      "subject": "di",
+      "object": "diph",
+      "dependentPossessive": "da",
+      "independentPossessive": "das",
+      "reflexive": "diphdaself"
+    },
+    {
+      "subject": "di",
+      "object": "dirge",
+      "dependentPossessive": "dir",
+      "independentPossessive": "dirs",
+      "reflexive": "dirgeself"
+    },
+    {
+      "subject": "di",
+      "object": "div",
+      "dependentPossessive": "divs",
+      "independentPossessive": "divs",
+      "reflexive": "divself"
+    },
+    {
+      "subject": "di",
+      "object": "div",
+      "dependentPossessive": "iv",
+      "independentPossessive": "ive",
+      "reflexive": "diveself"
+    },
+    {
+      "subject": "di",
+      "object": "il",
+      "dependentPossessive": "dill",
+      "independentPossessive": "dills",
+      "reflexive": "dillself"
+    },
+    {
+      "subject": "di",
+      "object": "in",
+      "dependentPossessive": "an",
+      "independentPossessive": "ana",
+      "reflexive": "indianaself"
+    },
+    {
+      "subject": "di",
+      "object": "syn",
+      "dependentPossessive": "kaios",
+      "independentPossessive": "kaiosyne",
+      "reflexive": "dikaiosyneself"
+    },
+    {
+      "subject": "div",
+      "object": "div",
+      "dependentPossessive": "divs",
+      "independentPossessive": "divs",
+      "reflexive": "divself"
+    },
+    {
+      "subject": "do",
+      "object": "doc",
+      "dependentPossessive": "doct",
+      "independentPossessive": "docto",
+      "reflexive": "doctorself"
+    },
+    {
+      "subject": "do",
+      "object": "dog",
+      "dependentPossessive": "gwo",
+      "independentPossessive": "gwod",
+      "reflexive": "dogwoodself"
+    },
+    {
+      "subject": "do",
+      "object": "dog",
+      "dependentPossessive": "og",
+      "independentPossessive": "og",
+      "reflexive": "dogself"
+    },
+    {
+      "subject": "do",
+      "object": "dor",
+      "dependentPossessive": "rad",
+      "independentPossessive": "rado",
+      "reflexive": "doradoself"
+    },
+    {
+      "subject": "do",
+      "object": "doub",
+      "dependentPossessive": "dol",
+      "independentPossessive": "double",
+      "reflexive": "doubleself"
+    },
+    {
+      "subject": "doc",
+      "object": "docx",
+      "dependentPossessive": "docs",
+      "independentPossessive": "docxs",
+      "reflexive": "docxself"
+    },
+    {
+      "subject": "dol",
+      "object": "dolci",
+      "dependentPossessive": "dolcis",
+      "independentPossessive": "dolcis",
+      "reflexive": "dolciself"
+    },
+    {
+      "subject": "dou",
+      "object": "double",
+      "dependentPossessive": "doubles",
+      "independentPossessive": "doubles",
+      "reflexive": "doubleself"
+    },
+    {
+      "subject": "dra",
+      "object": "drac",
+      "dependentPossessive": "drac",
+      "independentPossessive": "drax",
+      "reflexive": "dracoself"
+    },
+    {
+      "subject": "dra",
+      "object": "drake",
+      "dependentPossessive": "dras",
+      "independentPossessive": "dras",
+      "reflexive": "draself"
+    },
+    {
+      "subject": "dra",
+      "object": "gon",
+      "dependentPossessive": "fruits",
+      "independentPossessive": "fruits",
+      "reflexive": "dragonself"
+    },
+    {
+      "subject": "dry",
+      "object": "dryad",
+      "dependentPossessive": "drys",
+      "independentPossessive": "dryas",
+      "reflexive": "dryaself"
+    },
+    {
+      "subject": "du",
+      "object": "dub",
+      "dependentPossessive": "ub",
+      "independentPossessive": "ubhe",
+      "reflexive": "dubheself"
+    },
+    {
+      "subject": "du",
+      "object": "duet",
+      "dependentPossessive": "de",
+      "independentPossessive": "det",
+      "reflexive": "duetself"
+    },
+    {
+      "subject": "du",
+      "object": "oud",
+      "dependentPossessive": "do",
+      "independentPossessive": "duo",
+      "reflexive": "duoself"
+    },
+    {
+      "subject": "du",
+      "object": "rian",
+      "dependentPossessive": "dus",
+      "independentPossessive": "rians",
+      "reflexive": "durianself"
+    },
+    {
+      "subject": "dul",
+      "object": "dulce",
+      "dependentPossessive": "dulces",
+      "independentPossessive": "dulces",
+      "reflexive": "dulceself"
+    },
+    {
+      "subject": "dulla",
+      "object": "han",
+      "dependentPossessive": "dulls",
+      "independentPossessive": "dulls",
+      "reflexive": "dullself"
+    },
+    {
+      "subject": "dy",
+      "object": "dyd",
+      "dependentPossessive": "dya",
+      "independentPossessive": "dyad",
+      "reflexive": "dyadself"
+    },
+    {
+      "subject": "dy",
+      "object": "dym",
+      "dependentPossessive": "dyr",
+      "independentPossessive": "dyrs",
+      "reflexive": "dymself"
+    },
+    {
+      "subject": "e",
+      "object": "chid",
+      "dependentPossessive": "chis",
+      "independentPossessive": "chis",
+      "reflexive": "echidself"
+    },
+    {
+      "subject": "e",
+      "object": "clair",
+      "dependentPossessive": "clair",
+      "independentPossessive": "clairs",
+      "reflexive": "eclairself"
+    },
+    {
+      "subject": "e",
+      "object": "e",
+      "dependentPossessive": "e’s",
+      "independentPossessive": "e’s",
+      "reflexive": "eself"
+    },
+    {
+      "subject": "e",
+      "object": "east",
+      "dependentPossessive": "es",
+      "independentPossessive": "eas",
+      "reflexive": "eastself"
+    },
+    {
+      "subject": "e",
+      "object": "eir",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "eirself"
+    },
+    {
+      "subject": "e",
+      "object": "ele",
+      "dependentPossessive": "es",
+      "independentPossessive": "eles",
+      "reflexive": "eleself"
+    },
+    {
+      "subject": "e",
+      "object": "em",
+      "dependentPossessive": "e's",
+      "independentPossessive": "e's",
+      "reflexive": "emself"
+    },
+    {
       "subject": "e",
       "object": "em",
       "dependentPossessive": "eir",
       "independentPossessive": "eirs",
       "reflexive": "emself"
+    },
+    {
+      "subject": "e",
+      "object": "em",
+      "dependentPossessive": "er",
+      "independentPossessive": "ers",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "e",
+      "object": "em",
+      "dependentPossessive": "es",
+      "independentPossessive": "es",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "e",
+      "object": "em",
+      "dependentPossessive": "ir",
+      "independentPossessive": "irs",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "e",
+      "object": "im",
+      "dependentPossessive": "er",
+      "independentPossessive": "ers",
+      "reflexive": "imself"
+    },
+    {
+      "subject": "e",
+      "object": "tude",
+      "dependentPossessive": "tudes",
+      "independentPossessive": "tudes",
+      "reflexive": "etudeself"
+    },
+    {
+      "subject": "eche",
+      "object": "veria",
+      "dependentPossessive": "ver",
+      "independentPossessive": "veries",
+      "reflexive": "echeself"
+    },
+    {
+      "subject": "eev",
+      "object": "eevee",
+      "dependentPossessive": "eevees",
+      "independentPossessive": "eevees",
+      "reflexive": "eeveeself"
+    },
+    {
+      "subject": "ei",
+      "object": "eight",
+      "dependentPossessive": "eights",
+      "independentPossessive": "eights",
+      "reflexive": "eightself"
+    },
+    {
+      "subject": "ei",
+      "object": "eim",
+      "dependentPossessive": "eir",
+      "independentPossessive": "eirs",
+      "reflexive": "eimself"
+    },
+    {
+      "subject": "eis",
+      "object": "eis",
+      "dependentPossessive": "eis",
+      "independentPossessive": "eis",
+      "reflexive": "eisself"
+    },
+    {
+      "subject": "ele",
+      "object": "gy",
+      "dependentPossessive": "gys",
+      "independentPossessive": "gys",
+      "reflexive": "eleself"
+    },
+    {
+      "subject": "elf",
+      "object": "elven",
+      "dependentPossessive": "vens",
+      "independentPossessive": "vens",
+      "reflexive": "elfself"
+    },
+    {
+      "subject": "en",
+      "object": "core",
+      "dependentPossessive": "cores",
+      "independentPossessive": "cores",
+      "reflexive": "coreself"
+    },
+    {
+      "subject": "en",
+      "object": "end",
+      "dependentPossessive": "endocer",
+      "independentPossessive": "endocera",
+      "reflexive": "endoceraself"
+    },
+    {
+      "subject": "en",
+      "object": "tombed",
+      "dependentPossessive": "tombs",
+      "independentPossessive": "tombs",
+      "reflexive": "tombself"
+    },
+    {
+      "subject": "epi",
+      "object": "ep",
+      "dependentPossessive": "epil",
+      "independentPossessive": "epilo",
+      "reflexive": "epilogueself"
+    },
+    {
+      "subject": "eq",
+      "object": "equ",
+      "dependentPossessive": "equs",
+      "independentPossessive": "equs",
+      "reflexive": "equself"
+    },
+    {
+      "subject": "equi",
+      "object": "equil",
+      "dependentPossessive": "equili",
+      "independentPossessive": "equilibri",
+      "reflexive": "equiself"
+    },
+    {
+      "subject": "et",
+      "object": "em",
+      "dependentPossessive": "eri",
+      "independentPossessive": "eris",
+      "reflexive": "etself"
+    },
+    {
+      "subject": "et",
+      "object": "eta",
+      "dependentPossessive": "etas",
+      "independentPossessive": "etas",
+      "reflexive": "etaself"
+    },
+    {
+      "subject": "exe",
+      "object": "exe",
+      "dependentPossessive": "exe",
+      "independentPossessive": "exes",
+      "reflexive": "txtself"
     },
     {
       "subject": "ey",
@@ -72,11 +2536,95 @@
       "reflexive": "emself"
     },
     {
+      "subject": "ey",
+      "object": "em",
+      "dependentPossessive": "eyr",
+      "independentPossessive": "eyrs",
+      "reflexive": "emself"
+    },
+    {
+      "subject": "ey",
+      "object": "eym",
+      "dependentPossessive": "eyr",
+      "independentPossessive": "eyrs",
+      "reflexive": "eymself"
+    },
+    {
+      "subject": "f",
+      "object": "f",
+      "dependentPossessive": "f’s",
+      "independentPossessive": "f’s",
+      "reflexive": "fself"
+    },
+    {
+      "subject": "fa",
+      "object": "fal",
+      "dependentPossessive": "alc",
+      "independentPossessive": "alcon",
+      "reflexive": "falconself"
+    },
+    {
+      "subject": "fa",
+      "object": "fal",
+      "dependentPossessive": "fals",
+      "independentPossessive": "fals",
+      "reflexive": "fallself"
+    },
+    {
+      "subject": "fa",
+      "object": "fan",
+      "dependentPossessive": "fant",
+      "independentPossessive": "fantas",
+      "reflexive": "fantaself"
+    },
+    {
+      "subject": "fae",
+      "object": "faem",
+      "dependentPossessive": "faer",
+      "independentPossessive": "faers",
+      "reflexive": "faemself"
+    },
+    {
       "subject": "fae",
       "object": "faer",
       "dependentPossessive": "faer",
       "independentPossessive": "faers",
       "reflexive": "faerself"
+    },
+    {
+      "subject": "fae",
+      "object": "fim",
+      "dependentPossessive": "faer",
+      "independentPossessive": "faers",
+      "reflexive": "fimself"
+    },
+    {
+      "subject": "fairy",
+      "object": "bread",
+      "dependentPossessive": "fair",
+      "independentPossessive": "fairies",
+      "reflexive": "fairyself"
+    },
+    {
+      "subject": "fay",
+      "object": "fayr",
+      "dependentPossessive": "fays",
+      "independentPossessive": "fays",
+      "reflexive": "fayself"
+    },
+    {
+      "subject": "fe",
+      "object": "fyc",
+      "dependentPossessive": "fycs",
+      "independentPossessive": "fycs",
+      "reflexive": "fycself"
+    },
+    {
+      "subject": "fern",
+      "object": "fern",
+      "dependentPossessive": "ferns",
+      "independentPossessive": "ferns",
+      "reflexive": "fernself"
     },
     {
       "subject": "fey",
@@ -86,11 +2634,144 @@
       "reflexive": "feyself"
     },
     {
+      "subject": "fey",
+      "object": "fir",
+      "dependentPossessive": "fir",
+      "independentPossessive": "firs",
+      "reflexive": "firself"
+    },
+    {
+      "subject": "fi",
+      "object": "fer",
+      "dependentPossessive": "fer",
+      "independentPossessive": "fers",
+      "reflexive": "ferself"
+    },
+    {
+      "subject": "fi",
+      "object": "fid",
+      "dependentPossessive": "del",
+      "independentPossessive": "idel",
+      "reflexive": "fiddleself"
+    },
+    {
       "subject": "fi",
       "object": "fil",
       "dependentPossessive": "fil",
       "independentPossessive": "fils",
       "reflexive": "filself"
+    },
+    {
+      "subject": "fi",
+      "object": "fin",
+      "dependentPossessive": "fin",
+      "independentPossessive": "finch",
+      "reflexive": "finchself"
+    },
+    {
+      "subject": "fi",
+      "object": "fir",
+      "dependentPossessive": "fir",
+      "independentPossessive": "firs",
+      "reflexive": "firself"
+    },
+    {
+      "subject": "fi",
+      "object": "fir",
+      "dependentPossessive": "fire",
+      "independentPossessive": "firey",
+      "reflexive": "fireself"
+    },
+    {
+      "subject": "fi",
+      "object": "five",
+      "dependentPossessive": "fis",
+      "independentPossessive": "fives",
+      "reflexive": "fiveself"
+    },
+    {
+      "subject": "fi",
+      "object": "in",
+      "dependentPossessive": "infi",
+      "independentPossessive": "infin",
+      "reflexive": "infiniself"
+    },
+    {
+      "subject": "fie",
+      "object": "fiel",
+      "dependentPossessive": "il",
+      "independentPossessive": "ild",
+      "reflexive": "fieldself"
+    },
+    {
+      "subject": "fig",
+      "object": "fig",
+      "dependentPossessive": "figs",
+      "independentPossessive": "figs",
+      "reflexive": "figself"
+    },
+    {
+      "subject": "fir",
+      "object": "fir",
+      "dependentPossessive": "fir",
+      "independentPossessive": "firs",
+      "reflexive": "firself"
+    },
+    {
+      "subject": "fir",
+      "object": "fir",
+      "dependentPossessive": "frog",
+      "independentPossessive": "frogs",
+      "reflexive": "frogself"
+    },
+    {
+      "subject": "fla",
+      "object": "flan",
+      "dependentPossessive": "flans",
+      "independentPossessive": "flans",
+      "reflexive": "flanself"
+    },
+    {
+      "subject": "flo",
+      "object": "flor",
+      "dependentPossessive": "flori",
+      "independentPossessive": "florid",
+      "reflexive": "floridaself"
+    },
+    {
+      "subject": "flo",
+      "object": "flor",
+      "dependentPossessive": "flori",
+      "independentPossessive": "florid",
+      "reflexive": "floridself"
+    },
+    {
+      "subject": "flo",
+      "object": "flor",
+      "dependentPossessive": "res",
+      "independentPossessive": "res",
+      "reflexive": "floreself"
+    },
+    {
+      "subject": "flo",
+      "object": "flow",
+      "dependentPossessive": "flows",
+      "independentPossessive": "floweys",
+      "reflexive": "floweyself"
+    },
+    {
+      "subject": "float",
+      "object": "float",
+      "dependentPossessive": "floats",
+      "independentPossessive": "floats",
+      "reflexive": "floatself"
+    },
+    {
+      "subject": "fo",
+      "object": "foa",
+      "dependentPossessive": "foal",
+      "independentPossessive": "foals",
+      "reflexive": "foaself"
     },
     {
       "subject": "fo",
@@ -100,11 +2781,711 @@
       "reflexive": "foself"
     },
     {
+      "subject": "fo",
+      "object": "for",
+      "dependentPossessive": "fores",
+      "independentPossessive": "forest",
+      "reflexive": "forestself"
+    },
+    {
+      "subject": "fo",
+      "object": "mal",
+      "dependentPossessive": "hau",
+      "independentPossessive": "haut",
+      "reflexive": "fomalhautself"
+    },
+    {
+      "subject": "fon",
+      "object": "dant",
+      "dependentPossessive": "fons",
+      "independentPossessive": "fons",
+      "reflexive": "fonself"
+    },
+    {
+      "subject": "fra",
+      "object": "frost",
+      "dependentPossessive": "fros",
+      "independentPossessive": "fros",
+      "reflexive": "frostself"
+    },
+    {
+      "subject": "fri",
+      "object": "fer",
+      "dependentPossessive": "frid",
+      "independentPossessive": "frida",
+      "reflexive": "fridayself"
+    },
+    {
+      "subject": "frie",
+      "object": "friez",
+      "dependentPossessive": "freesi",
+      "independentPossessive": "freesi",
+      "reflexive": "freesiaself"
+    },
+    {
+      "subject": "fris",
+      "object": "frisk",
+      "dependentPossessive": "frisks",
+      "independentPossessive": "frisks",
+      "reflexive": "friskself"
+    },
+    {
+      "subject": "fro",
+      "object": "froyo",
+      "dependentPossessive": "yos",
+      "independentPossessive": "yos",
+      "reflexive": "froyoself"
+    },
+    {
+      "subject": "frost",
+      "object": "frosted",
+      "dependentPossessive": "frosts",
+      "independentPossessive": "frosteds",
+      "reflexive": "frostedself"
+    },
+    {
+      "subject": "frost",
+      "object": "frosting",
+      "dependentPossessive": "frosts",
+      "independentPossessive": "frosts",
+      "reflexive": "frostself"
+    },
+    {
+      "subject": "fu",
+      "object": "fot",
+      "dependentPossessive": "ot",
+      "independentPossessive": "oot",
+      "reflexive": "footself"
+    },
+    {
+      "subject": "fu",
+      "object": "fuch",
+      "dependentPossessive": "uch",
+      "independentPossessive": "uchia",
+      "reflexive": "fuchsiaself"
+    },
+    {
+      "subject": "fu",
+      "object": "fudge",
+      "dependentPossessive": "fus",
+      "independentPossessive": "fus",
+      "reflexive": "fudgeself"
+    },
+    {
+      "subject": "fu",
+      "object": "futu",
+      "dependentPossessive": "feut",
+      "independentPossessive": "feutur",
+      "reflexive": "futureself"
+    },
+    {
+      "subject": "fu",
+      "object": "gue",
+      "dependentPossessive": "gues",
+      "independentPossessive": "gues",
+      "reflexive": "fugueself"
+    },
+    {
+      "subject": "g",
+      "object": "g",
+      "dependentPossessive": "g’s",
+      "independentPossessive": "g’s",
+      "reflexive": "gself"
+    },
+    {
+      "subject": "ga",
+      "object": "gac",
+      "dependentPossessive": "ux",
+      "independentPossessive": "rux",
+      "reflexive": "gacruxself"
+    },
+    {
+      "subject": "ga",
+      "object": "gal",
+      "dependentPossessive": "gala",
+      "independentPossessive": "galax",
+      "reflexive": "galaself"
+    },
+    {
+      "subject": "ga",
+      "object": "gal",
+      "dependentPossessive": "galle",
+      "independentPossessive": "galleon",
+      "reflexive": "galleonself"
+    },
+    {
+      "subject": "ga",
+      "object": "gam",
+      "dependentPossessive": "gamma",
+      "independentPossessive": "gamma",
+      "reflexive": "gammaself"
+    },
+    {
+      "subject": "ga",
+      "object": "gar",
+      "dependentPossessive": "gard",
+      "independentPossessive": "garden",
+      "reflexive": "gardenself"
+    },
+    {
+      "subject": "ga",
+      "object": "gat",
+      "dependentPossessive": "tor",
+      "independentPossessive": "gator",
+      "reflexive": "alligatorself"
+    },
+    {
+      "subject": "ga",
+      "object": "gau",
+      "dependentPossessive": "gauz",
+      "independentPossessive": "gauz",
+      "reflexive": "gauzeself"
+    },
+    {
+      "subject": "ga",
+      "object": "nache",
+      "dependentPossessive": "nache",
+      "independentPossessive": "naches",
+      "reflexive": "ganacheself"
+    },
+    {
+      "subject": "ga",
+      "object": "steria",
+      "dependentPossessive": "ster",
+      "independentPossessive": "steries",
+      "reflexive": "gasteriaself"
+    },
+    {
+      "subject": "ga",
+      "object": "teau",
+      "dependentPossessive": "teaus",
+      "independentPossessive": "teaus",
+      "reflexive": "gateauself"
+    },
+    {
+      "subject": "ga",
+      "object": "teaux",
+      "dependentPossessive": "teauxs",
+      "independentPossessive": "teauxs",
+      "reflexive": "gateauxself"
+    },
+    {
+      "subject": "ga",
+      "object": "votte",
+      "dependentPossessive": "vottes",
+      "independentPossessive": "vottes",
+      "reflexive": "gavotteself"
+    },
+    {
+      "subject": "gar",
+      "object": "goyle",
+      "dependentPossessive": "gars",
+      "independentPossessive": "gars",
+      "reflexive": "garself"
+    },
+    {
       "subject": "ge",
       "object": "gel",
       "dependentPossessive": "gel",
       "independentPossessive": "gels",
       "reflexive": "gelself"
+    },
+    {
+      "subject": "ge",
+      "object": "gel",
+      "dependentPossessive": "gels",
+      "independentPossessive": "gelly",
+      "reflexive": "gelself"
+    },
+    {
+      "subject": "ge",
+      "object": "gem",
+      "dependentPossessive": "gur",
+      "independentPossessive": "gurs",
+      "reflexive": "gemself"
+    },
+    {
+      "subject": "ge",
+      "object": "geo",
+      "dependentPossessive": "ged",
+      "independentPossessive": "geode",
+      "reflexive": "geodeself"
+    },
+    {
+      "subject": "ge",
+      "object": "ger",
+      "dependentPossessive": "ges",
+      "independentPossessive": "gers",
+      "reflexive": "gerself"
+    },
+    {
+      "subject": "ge",
+      "object": "ger",
+      "dependentPossessive": "gis",
+      "independentPossessive": "gis",
+      "reflexive": "gerself"
+    },
+    {
+      "subject": "ge",
+      "object": "noise",
+      "dependentPossessive": "nois",
+      "independentPossessive": "noise",
+      "reflexive": "genoiseself"
+    },
+    {
+      "subject": "ge",
+      "object": "org",
+      "dependentPossessive": "geor",
+      "independentPossessive": "georg",
+      "reflexive": "georgiaself"
+    },
+    {
+      "subject": "gel",
+      "object": "gelato",
+      "dependentPossessive": "gels",
+      "independentPossessive": "gelas",
+      "reflexive": "gelaself"
+    },
+    {
+      "subject": "gela",
+      "object": "tin",
+      "dependentPossessive": "gelas",
+      "independentPossessive": "gelas",
+      "reflexive": "gelaself"
+    },
+    {
+      "subject": "geth",
+      "object": "geth",
+      "dependentPossessive": "geths",
+      "independentPossessive": "geths",
+      "reflexive": "gethself"
+    },
+    {
+      "subject": "ghou",
+      "object": "ghoul",
+      "dependentPossessive": "ghous",
+      "independentPossessive": "ghouls",
+      "reflexive": "ghoulself"
+    },
+    {
+      "subject": "gi",
+      "object": "gif",
+      "dependentPossessive": "gis",
+      "independentPossessive": "gifs",
+      "reflexive": "gifself"
+    },
+    {
+      "subject": "gi",
+      "object": "gif",
+      "dependentPossessive": "ift",
+      "independentPossessive": "gift",
+      "reflexive": "giftself"
+    },
+    {
+      "subject": "gia",
+      "object": "giant",
+      "dependentPossessive": "gias",
+      "independentPossessive": "gias",
+      "reflexive": "giaself"
+    },
+    {
+      "subject": "gina",
+      "object": "taan",
+      "dependentPossessive": "taans",
+      "independentPossessive": "taans",
+      "reflexive": "ginaself"
+    },
+    {
+      "subject": "gina",
+      "object": "taang",
+      "dependentPossessive": "taangs",
+      "independentPossessive": "taangs",
+      "reflexive": "ginaself"
+    },
+    {
+      "subject": "gir",
+      "object": "gra",
+      "dependentPossessive": "grass",
+      "independentPossessive": "grass",
+      "reflexive": "grasself"
+    },
+    {
+      "subject": "gla",
+      "object": "gal",
+      "dependentPossessive": "de",
+      "independentPossessive": "ade",
+      "reflexive": "gladeself"
+    },
+    {
+      "subject": "gla",
+      "object": "glaze",
+      "dependentPossessive": "glaz",
+      "independentPossessive": "glazes",
+      "reflexive": "glazeself"
+    },
+    {
+      "subject": "gla",
+      "object": "gol",
+      "dependentPossessive": "glass",
+      "independentPossessive": "glass",
+      "reflexive": "glasself"
+    },
+    {
+      "subject": "glaze",
+      "object": "glazed",
+      "dependentPossessive": "glaze",
+      "independentPossessive": "glazes",
+      "reflexive": "glazeself"
+    },
+    {
+      "subject": "gli",
+      "object": "gli",
+      "dependentPossessive": "glits",
+      "independentPossessive": "glits",
+      "reflexive": "glitself"
+    },
+    {
+      "subject": "glim",
+      "object": "glim",
+      "dependentPossessive": "glimmer",
+      "independentPossessive": "glimmers",
+      "reflexive": "glimself"
+    },
+    {
+      "subject": "glitch",
+      "object": "glitch",
+      "dependentPossessive": "glitch's",
+      "independentPossessive": "glitches",
+      "reflexive": "glitchself"
+    },
+    {
+      "subject": "glo",
+      "object": "gol",
+      "dependentPossessive": "glor",
+      "independentPossessive": "glory",
+      "reflexive": "gloryself"
+    },
+    {
+      "subject": "glu",
+      "object": "glue",
+      "dependentPossessive": "glus",
+      "independentPossessive": "glues",
+      "reflexive": "glueself"
+    },
+    {
+      "subject": "go",
+      "object": "ji",
+      "dependentPossessive": "jis",
+      "independentPossessive": "jis",
+      "reflexive": "gojiself"
+    },
+    {
+      "subject": "go",
+      "object": "lem",
+      "dependentPossessive": "gos",
+      "independentPossessive": "gos",
+      "reflexive": "golemself"
+    },
+    {
+      "subject": "gob",
+      "object": "goblin",
+      "dependentPossessive": "blins",
+      "independentPossessive": "blins",
+      "reflexive": "blinself"
+    },
+    {
+      "subject": "gol",
+      "object": "gold",
+      "dependentPossessive": "golds",
+      "independentPossessive": "golds",
+      "reflexive": "goldself"
+    },
+    {
+      "subject": "gor",
+      "object": "gorgon",
+      "dependentPossessive": "gor",
+      "independentPossessive": "gors",
+      "reflexive": "gorself"
+    },
+    {
+      "subject": "gra",
+      "object": "gran",
+      "dependentPossessive": "nit",
+      "independentPossessive": "anit",
+      "reflexive": "graniteself"
+    },
+    {
+      "subject": "grae",
+      "object": "grace",
+      "dependentPossessive": "graes",
+      "independentPossessive": "graces",
+      "reflexive": "graceself"
+    },
+    {
+      "subject": "grape",
+      "object": "grape",
+      "dependentPossessive": "grapes",
+      "independentPossessive": "grapes",
+      "reflexive": "grapeself"
+    },
+    {
+      "subject": "grapto",
+      "object": "petalum",
+      "dependentPossessive": "petals",
+      "independentPossessive": "petals",
+      "reflexive": "graptoself"
+    },
+    {
+      "subject": "grass",
+      "object": "jelly",
+      "dependentPossessive": "jellies",
+      "independentPossessive": "jellies",
+      "reflexive": "grassjellyself"
+    },
+    {
+      "subject": "green",
+      "object": "green",
+      "dependentPossessive": "greens",
+      "independentPossessive": "greens",
+      "reflexive": "greenself"
+    },
+    {
+      "subject": "grei",
+      "object": "gyr",
+      "dependentPossessive": "grace",
+      "independentPossessive": "grace",
+      "reflexive": "graceself"
+    },
+    {
+      "subject": "grey",
+      "object": "grey",
+      "dependentPossessive": "greys",
+      "independentPossessive": "greys",
+      "reflexive": "greyself"
+    },
+    {
+      "subject": "grif",
+      "object": "fin",
+      "dependentPossessive": "fins",
+      "independentPossessive": "fins",
+      "reflexive": "griffself"
+    },
+    {
+      "subject": "grif",
+      "object": "fon",
+      "dependentPossessive": "fons",
+      "independentPossessive": "fons",
+      "reflexive": "griffself"
+    },
+    {
+      "subject": "gro",
+      "object": "gore",
+      "dependentPossessive": "gross",
+      "independentPossessive": "gross",
+      "reflexive": "goreself"
+    },
+    {
+      "subject": "grou",
+      "object": "ger",
+      "dependentPossessive": "ouse",
+      "independentPossessive": "rous",
+      "reflexive": "grouseself"
+    },
+    {
+      "subject": "gry",
+      "object": "phon",
+      "dependentPossessive": "phons",
+      "independentPossessive": "phons",
+      "reflexive": "phonself"
+    },
+    {
+      "subject": "gu",
+      "object": "gam",
+      "dependentPossessive": "gua",
+      "independentPossessive": "guam",
+      "reflexive": "guamself"
+    },
+    {
+      "subject": "gu",
+      "object": "goose",
+      "dependentPossessive": "os",
+      "independentPossessive": "oos",
+      "reflexive": "gooseself"
+    },
+    {
+      "subject": "gu",
+      "object": "gum",
+      "dependentPossessive": "gums",
+      "independentPossessive": "gums",
+      "reflexive": "gumself"
+    },
+    {
+      "subject": "gua",
+      "object": "va",
+      "dependentPossessive": "guas",
+      "independentPossessive": "vas",
+      "reflexive": "guaself"
+    },
+    {
+      "subject": "gum",
+      "object": "gummy",
+      "dependentPossessive": "gums",
+      "independentPossessive": "gums",
+      "reflexive": "gummyself"
+    },
+    {
+      "subject": "h",
+      "object": "h",
+      "dependentPossessive": "h’s",
+      "independentPossessive": "h’s",
+      "reflexive": "hself"
+    },
+    {
+      "subject": "ha",
+      "object": "aw",
+      "dependentPossessive": "awa",
+      "independentPossessive": "hawa",
+      "reflexive": "hawai'iself"
+    },
+    {
+      "subject": "ha",
+      "object": "aw",
+      "dependentPossessive": "awa",
+      "independentPossessive": "hawa",
+      "reflexive": "hawaiiself"
+    },
+    {
+      "subject": "ha",
+      "object": "hal",
+      "dependentPossessive": "af",
+      "independentPossessive": "half",
+      "reflexive": "halfself"
+    },
+    {
+      "subject": "ha",
+      "object": "hal",
+      "dependentPossessive": "an",
+      "independentPossessive": "lan",
+      "reflexive": "howlandself"
+    },
+    {
+      "subject": "ha",
+      "object": "hal",
+      "dependentPossessive": "ma",
+      "independentPossessive": "maher",
+      "reflexive": "halmaheraself"
+    },
+    {
+      "subject": "ha",
+      "object": "hal",
+      "dependentPossessive": "mal",
+      "independentPossessive": "mal",
+      "reflexive": "hamalself"
+    },
+    {
+      "subject": "ha",
+      "object": "han",
+      "dependentPossessive": "had",
+      "independentPossessive": "hand",
+      "reflexive": "handself"
+    },
+    {
+      "subject": "ha",
+      "object": "hap",
+      "dependentPossessive": "py",
+      "independentPossessive": "appy",
+      "reflexive": "happyself"
+    },
+    {
+      "subject": "ha",
+      "object": "hav",
+      "dependentPossessive": "ven",
+      "independentPossessive": "aven",
+      "reflexive": "havenself"
+    },
+    {
+      "subject": "ha",
+      "object": "hawk",
+      "dependentPossessive": "haw",
+      "independentPossessive": "awk",
+      "reflexive": "hawkself"
+    },
+    {
+      "subject": "ha",
+      "object": "hib",
+      "dependentPossessive": "bis",
+      "independentPossessive": "cus",
+      "reflexive": "hibiscuself"
+    },
+    {
+      "subject": "ha",
+      "object": "hol",
+      "dependentPossessive": "ly",
+      "independentPossessive": "olly",
+      "reflexive": "hollyself"
+    },
+    {
+      "subject": "hae",
+      "object": "hael",
+      "dependentPossessive": "halle",
+      "independentPossessive": "halo",
+      "reflexive": "haloself"
+    },
+    {
+      "subject": "halo",
+      "object": "halo-halo",
+      "dependentPossessive": "halos",
+      "independentPossessive": "halos",
+      "reflexive": "halo-haloself"
+    },
+    {
+      "subject": "haw",
+      "object": "hawth",
+      "dependentPossessive": "thor",
+      "independentPossessive": "thorn",
+      "reflexive": "hawthornself"
+    },
+    {
+      "subject": "haz",
+      "object": "hazel",
+      "dependentPossessive": "zels",
+      "independentPossessive": "zels",
+      "reflexive": "hazelself"
+    },
+    {
+      "subject": "he",
+      "object": "hel",
+      "dependentPossessive": "hellos",
+      "independentPossessive": "hellos",
+      "reflexive": "helloself"
+    },
+    {
+      "subject": "he",
+      "object": "hem",
+      "dependentPossessive": "heii",
+      "independentPossessive": "hemi",
+      "reflexive": "hemiself"
+    },
+    {
+      "subject": "he",
+      "object": "hept",
+      "dependentPossessive": "hepta",
+      "independentPossessive": "heptad",
+      "reflexive": "heptadself"
+    },
+    {
+      "subject": "he",
+      "object": "her",
+      "dependentPossessive": "heo",
+      "independentPossessive": "hero",
+      "reflexive": "heroself"
+    },
+    {
+      "subject": "he",
+      "object": "hex",
+      "dependentPossessive": "hexa",
+      "independentPossessive": "hexad",
+      "reflexive": "hexadself"
     },
     {
       "subject": "he",
@@ -114,11 +3495,347 @@
       "reflexive": "himself"
     },
     {
+      "subject": "he'er",
+      "object": "him'er",
+      "dependentPossessive": "his'er",
+      "independentPossessive": "his'er's",
+      "reflexive": "his'er'self"
+    },
+    {
+      "subject": "hea",
+      "object": "hearth",
+      "dependentPossessive": "hear",
+      "independentPossessive": "hearths",
+      "reflexive": "hearthself"
+    },
+    {
+      "subject": "hell",
+      "object": "hound",
+      "dependentPossessive": "hells",
+      "independentPossessive": "hounds",
+      "reflexive": "houndself"
+    },
+    {
+      "subject": "hell",
+      "object": "hund",
+      "dependentPossessive": "hells",
+      "independentPossessive": "hunds",
+      "reflexive": "hundself"
+    },
+    {
+      "subject": "hesh",
+      "object": "hiser",
+      "dependentPossessive": "himer",
+      "independentPossessive": "himer",
+      "reflexive": "hermself"
+    },
+    {
+      "subject": "hi",
+      "object": "hill",
+      "dependentPossessive": "hills",
+      "independentPossessive": "hills",
+      "reflexive": "hillself"
+    },
+    {
+      "subject": "hi",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "hin",
+      "object": "hin",
+      "dependentPossessive": "hins",
+      "independentPossessive": "hins",
+      "reflexive": "hinself"
+    },
+    {
+      "subject": "hippo",
+      "object": "campus",
+      "dependentPossessive": "camps",
+      "independentPossessive": "camps",
+      "reflexive": "hippoself"
+    },
+    {
+      "subject": "hippo",
+      "object": "griff",
+      "dependentPossessive": "griffs",
+      "independentPossessive": "griffs",
+      "reflexive": "hippoself"
+    },
+    {
+      "subject": "honey",
+      "object": "dew",
+      "dependentPossessive": "dews",
+      "independentPossessive": "dews",
+      "reflexive": "honeyself"
+    },
+    {
+      "subject": "hoof",
+      "object": "hoof",
+      "dependentPossessive": "hooves",
+      "independentPossessive": "hooves",
+      "reflexive": "hoofself"
+    },
+    {
+      "subject": "ht",
+      "object": "htm",
+      "dependentPossessive": "hts",
+      "independentPossessive": "hts",
+      "reflexive": "htmself"
+    },
+    {
+      "subject": "ht",
+      "object": "html",
+      "dependentPossessive": "hts",
+      "independentPossessive": "hts",
+      "reflexive": "htmlself"
+    },
+    {
+      "subject": "hu",
+      "object": "hum",
+      "dependentPossessive": "hums",
+      "independentPossessive": "hums",
+      "reflexive": "humself"
+    },
+    {
       "subject": "hu",
       "object": "hum",
       "dependentPossessive": "hus",
       "independentPossessive": "hus",
       "reflexive": "humself"
+    },
+    {
+      "subject": "hu",
+      "object": "hum",
+      "dependentPossessive": "hus",
+      "independentPossessive": "hus",
+      "reflexive": "huself"
+    },
+    {
+      "subject": "hush",
+      "object": "hush",
+      "dependentPossessive": "hushs",
+      "independentPossessive": "hushs",
+      "reflexive": "hushself"
+    },
+    {
+      "subject": "hx",
+      "object": "hxm",
+      "dependentPossessive": "hxs",
+      "independentPossessive": "hxs",
+      "reflexive": "hxmself"
+    },
+    {
+      "subject": "hy",
+      "object": "cin",
+      "dependentPossessive": "hyas",
+      "independentPossessive": "hyacin",
+      "reflexive": "hyacinthself"
+    },
+    {
+      "subject": "hy",
+      "object": "hymn",
+      "dependentPossessive": "hymns",
+      "independentPossessive": "hymns",
+      "reflexive": "hymnself"
+    },
+    {
+      "subject": "ia",
+      "object": "oh",
+      "dependentPossessive": "io",
+      "independentPossessive": "oa",
+      "reflexive": "iowaself"
+    },
+    {
+      "subject": "ice",
+      "object": "ice",
+      "dependentPossessive": "ices",
+      "independentPossessive": "ices",
+      "reflexive": "iceself"
+    },
+    {
+      "subject": "ice",
+      "object": "iced",
+      "dependentPossessive": "ices",
+      "independentPossessive": "iceds",
+      "reflexive": "icedself"
+    },
+    {
+      "subject": "ice",
+      "object": "icing",
+      "dependentPossessive": "cings",
+      "independentPossessive": "cings",
+      "reflexive": "icingself"
+    },
+    {
+      "subject": "id",
+      "object": "idre",
+      "dependentPossessive": "ids",
+      "independentPossessive": "ids",
+      "reflexive": "idself"
+    },
+    {
+      "subject": "ide",
+      "object": "id",
+      "dependentPossessive": "ida",
+      "independentPossessive": "idea",
+      "reflexive": "ideaself"
+    },
+    {
+      "subject": "ie",
+      "object": "ice",
+      "dependentPossessive": "isse",
+      "independentPossessive": "issi",
+      "reflexive": "iceself"
+    },
+    {
+      "subject": "ie",
+      "object": "ie",
+      "dependentPossessive": "i’s",
+      "independentPossessive": "i’s",
+      "reflexive": "iself"
+    },
+    {
+      "subject": "if",
+      "object": "if",
+      "dependentPossessive": "ifs",
+      "independentPossessive": "ifs",
+      "reflexive": "ifself"
+    },
+    {
+      "subject": "ih",
+      "object": "ink",
+      "dependentPossessive": "inx",
+      "independentPossessive": "inx",
+      "reflexive": "inxelf"
+    },
+    {
+      "subject": "im",
+      "object": "prov",
+      "dependentPossessive": "provs",
+      "independentPossessive": "provs",
+      "reflexive": "provself"
+    },
+    {
+      "subject": "imp",
+      "object": "imp",
+      "dependentPossessive": "imps",
+      "independentPossessive": "imps",
+      "reflexive": "impself"
+    },
+    {
+      "subject": "in",
+      "object": "dex",
+      "dependentPossessive": "ins",
+      "independentPossessive": "dexs",
+      "reflexive": "indexself"
+    },
+    {
+      "subject": "in",
+      "object": "fern",
+      "dependentPossessive": "fer",
+      "independentPossessive": "fers",
+      "reflexive": "fernself"
+    },
+    {
+      "subject": "in",
+      "object": "in",
+      "dependentPossessive": "ins",
+      "independentPossessive": "ins",
+      "reflexive": "inself"
+    },
+    {
+      "subject": "in",
+      "object": "incu",
+      "dependentPossessive": "bus",
+      "independentPossessive": "bus",
+      "reflexive": "incuself"
+    },
+    {
+      "subject": "in",
+      "object": "ind",
+      "dependentPossessive": "indi",
+      "independentPossessive": "indig",
+      "reflexive": "indigoself"
+    },
+    {
+      "subject": "in",
+      "object": "ink",
+      "dependentPossessive": "inks",
+      "independentPossessive": "inks",
+      "reflexive": "inkself"
+    },
+    {
+      "subject": "in",
+      "object": "input",
+      "dependentPossessive": "ins",
+      "independentPossessive": "inputs",
+      "reflexive": "inputself"
+    },
+    {
+      "subject": "in",
+      "object": "inst",
+      "dependentPossessive": "ins",
+      "independentPossessive": "ins",
+      "reflexive": "instinctself"
+    },
+    {
+      "subject": "in",
+      "object": "int",
+      "dependentPossessive": "ints",
+      "independentPossessive": "ints",
+      "reflexive": "intself"
+    },
+    {
+      "subject": "ind",
+      "object": "indust",
+      "dependentPossessive": "indus",
+      "independentPossessive": "industria",
+      "reflexive": "industriself"
+    },
+    {
+      "subject": "ing",
+      "object": "ingre",
+      "dependentPossessive": "ingress",
+      "independentPossessive": "ingress",
+      "reflexive": "ingresself"
+    },
+    {
+      "subject": "io",
+      "object": "ion",
+      "dependentPossessive": "ioni",
+      "independentPossessive": "ionia",
+      "reflexive": "ionianself"
+    },
+    {
+      "subject": "ip",
+      "object": "ip",
+      "dependentPossessive": "ips",
+      "independentPossessive": "ips",
+      "reflexive": "ipsself"
+    },
+    {
+      "subject": "ir",
+      "object": "im",
+      "dependentPossessive": "iro",
+      "independentPossessive": "iros",
+      "reflexive": "iroself"
+    },
+    {
+      "subject": "ir",
+      "object": "ir",
+      "dependentPossessive": "iris",
+      "independentPossessive": "iri",
+      "reflexive": "iriself"
+    },
+    {
+      "subject": "ir",
+      "object": "ire",
+      "dependentPossessive": "iro",
+      "independentPossessive": "iros",
+      "reflexive": "ireself"
     },
     {
       "subject": "it",
@@ -128,11 +3845,326 @@
       "reflexive": "itself"
     },
     {
+      "subject": "it",
+      "object": "its",
+      "dependentPossessive": "it",
+      "independentPossessive": "its",
+      "reflexive": "itself"
+    },
+    {
+      "subject": "j",
+      "object": "j",
+      "dependentPossessive": "j’s",
+      "independentPossessive": "j’s",
+      "reflexive": "jself"
+    },
+    {
+      "subject": "j",
+      "object": "peg",
+      "dependentPossessive": "js",
+      "independentPossessive": "pegs",
+      "reflexive": "jpegself"
+    },
+    {
+      "subject": "j",
+      "object": "pg",
+      "dependentPossessive": "js",
+      "independentPossessive": "pgs",
+      "reflexive": "jpgself"
+    },
+    {
+      "subject": "ja",
+      "object": "java",
+      "dependentPossessive": "jav",
+      "independentPossessive": "javs",
+      "reflexive": "javaself"
+    },
+    {
+      "subject": "ja",
+      "object": "min",
+      "dependentPossessive": "jas",
+      "independentPossessive": "jasmi",
+      "reflexive": "jasmineself"
+    },
+    {
+      "subject": "jack",
+      "object": "fruit",
+      "dependentPossessive": "fruits",
+      "independentPossessive": "fruits",
+      "reflexive": "jackfruitself"
+    },
+    {
+      "subject": "jam",
+      "object": "jam",
+      "dependentPossessive": "jams",
+      "independentPossessive": "jams",
+      "reflexive": "jamself"
+    },
+    {
+      "subject": "java",
+      "object": "script",
+      "dependentPossessive": "scripts",
+      "independentPossessive": "scripts",
+      "reflexive": "scriptself"
+    },
+    {
+      "subject": "jay",
+      "object": "jem",
+      "dependentPossessive": "jaer",
+      "independentPossessive": "jaers",
+      "reflexive": "jemself"
+    },
+    {
+      "subject": "je",
+      "object": "jem",
+      "dependentPossessive": "jer",
+      "independentPossessive": "jers",
+      "reflexive": "jhemself"
+    },
+    {
+      "subject": "je",
+      "object": "jet",
+      "dependentPossessive": "jets",
+      "independentPossessive": "jets",
+      "reflexive": "jetself"
+    },
+    {
+      "subject": "je",
+      "object": "min",
+      "dependentPossessive": "jes",
+      "independentPossessive": "jessa",
+      "reflexive": "jessamineself"
+    },
+    {
       "subject": "jee",
       "object": "jem",
       "dependentPossessive": "jeir",
       "independentPossessive": "jeirs",
       "reflexive": "jemself"
+    },
+    {
+      "subject": "jel",
+      "object": "jello",
+      "dependentPossessive": "jels",
+      "independentPossessive": "jels",
+      "reflexive": "jelloself"
+    },
+    {
+      "subject": "jel",
+      "object": "jelly",
+      "dependentPossessive": "jels",
+      "independentPossessive": "jels",
+      "reflexive": "jellyself"
+    },
+    {
+      "subject": "jel",
+      "object": "jelm",
+      "dependentPossessive": "jelier",
+      "independentPossessive": "jels",
+      "reflexive": "jellyfish"
+    },
+    {
+      "subject": "jhe",
+      "object": "jem",
+      "dependentPossessive": "jeir",
+      "independentPossessive": "jeirs",
+      "reflexive": "jemself"
+    },
+    {
+      "subject": "ji",
+      "object": "jem",
+      "dependentPossessive": "jir",
+      "independentPossessive": "jirs",
+      "reflexive": "jemself"
+    },
+    {
+      "subject": "ji",
+      "object": "jin",
+      "dependentPossessive": "jix",
+      "independentPossessive": "jinx",
+      "reflexive": "jinxself"
+    },
+    {
+      "subject": "jo",
+      "object": "jol",
+      "dependentPossessive": "oyo",
+      "independentPossessive": "oyos",
+      "reflexive": "joyouself"
+    },
+    {
+      "subject": "jovi",
+      "object": "barba",
+      "dependentPossessive": "bar",
+      "independentPossessive": "barbs",
+      "reflexive": "joviself"
+    },
+    {
+      "subject": "js",
+      "object": "js",
+      "dependentPossessive": "js",
+      "independentPossessive": "js",
+      "reflexive": "jself"
+    },
+    {
+      "subject": "ju",
+      "object": "jung",
+      "dependentPossessive": "ung",
+      "independentPossessive": "ungle",
+      "reflexive": "jungleself"
+    },
+    {
+      "subject": "k",
+      "object": "k",
+      "dependentPossessive": "k’s",
+      "independentPossessive": "k’s",
+      "reflexive": "kself"
+    },
+    {
+      "subject": "ka",
+      "object": "alk",
+      "dependentPossessive": "kai",
+      "independentPossessive": "kaid",
+      "reflexive": "alkaidself"
+    },
+    {
+      "subject": "ka",
+      "object": "ar",
+      "dependentPossessive": "ark",
+      "independentPossessive": "arkan",
+      "reflexive": "arkansaself"
+    },
+    {
+      "subject": "ka",
+      "object": "kam",
+      "dependentPossessive": "kamel",
+      "independentPossessive": "kameleo",
+      "reflexive": "kameleoself"
+    },
+    {
+      "subject": "ka",
+      "object": "kap",
+      "dependentPossessive": "kappa",
+      "independentPossessive": "kappa",
+      "reflexive": "kappaself"
+    },
+    {
+      "subject": "ka",
+      "object": "kar",
+      "dependentPossessive": "ar",
+      "independentPossessive": "ara",
+      "reflexive": "karaself"
+    },
+    {
+      "subject": "ka",
+      "object": "kasp",
+      "dependentPossessive": "kaspi",
+      "independentPossessive": "kasperi",
+      "reflexive": "kaspself"
+    },
+    {
+      "subject": "kai",
+      "object": "kaim",
+      "dependentPossessive": "kais",
+      "independentPossessive": "kais",
+      "reflexive": "kaiself"
+    },
+    {
+      "subject": "kai",
+      "object": "kait",
+      "dependentPossessive": "tos",
+      "independentPossessive": "aitos",
+      "reflexive": "kaitoself"
+    },
+    {
+      "subject": "kaus",
+      "object": "austra",
+      "dependentPossessive": "aus",
+      "independentPossessive": "austras",
+      "reflexive": "kausself"
+    },
+    {
+      "subject": "kaus",
+      "object": "borea",
+      "dependentPossessive": "bores",
+      "independentPossessive": "bores",
+      "reflexive": "kausself"
+    },
+    {
+      "subject": "ke",
+      "object": "keb",
+      "dependentPossessive": "keor",
+      "independentPossessive": "kebor",
+      "reflexive": "keyboardself"
+    },
+    {
+      "subject": "ke",
+      "object": "kem",
+      "dependentPossessive": "keir",
+      "independentPossessive": "keirs",
+      "reflexive": "keirself"
+    },
+    {
+      "subject": "ke",
+      "object": "kem",
+      "dependentPossessive": "keir",
+      "independentPossessive": "keirs",
+      "reflexive": "kemself"
+    },
+    {
+      "subject": "ke",
+      "object": "kem",
+      "dependentPossessive": "kheir",
+      "independentPossessive": "kheirs",
+      "reflexive": "kemself"
+    },
+    {
+      "subject": "ke",
+      "object": "kem",
+      "dependentPossessive": "kir",
+      "independentPossessive": "kirs",
+      "reflexive": "kemself"
+    },
+    {
+      "subject": "ke",
+      "object": "ken",
+      "dependentPossessive": "kent",
+      "independentPossessive": "kentu",
+      "reflexive": "kentuckyself"
+    },
+    {
+      "subject": "ke",
+      "object": "key",
+      "dependentPossessive": "kes",
+      "independentPossessive": "keys",
+      "reflexive": "keyself"
+    },
+    {
+      "subject": "ki",
+      "object": "kir",
+      "dependentPossessive": "kirs",
+      "independentPossessive": "kirs",
+      "reflexive": "kirself"
+    },
+    {
+      "subject": "ki",
+      "object": "kite",
+      "dependentPossessive": "kies",
+      "independentPossessive": "kies",
+      "reflexive": "kiteself"
+    },
+    {
+      "subject": "ki",
+      "object": "kiwi",
+      "dependentPossessive": "kiwis",
+      "independentPossessive": "kiwis",
+      "reflexive": "kiwiself"
+    },
+    {
+      "subject": "kir",
+      "object": "kir",
+      "dependentPossessive": "kirs",
+      "independentPossessive": "kirs",
+      "reflexive": "kirself"
     },
     {
       "subject": "kit",
@@ -142,11 +4174,1299 @@
       "reflexive": "kitself"
     },
     {
+      "subject": "kno",
+      "object": "knot",
+      "dependentPossessive": "ot",
+      "independentPossessive": "kot",
+      "reflexive": "knotself"
+    },
+    {
+      "subject": "ko",
+      "object": "kor",
+      "dependentPossessive": "or",
+      "independentPossessive": "oro",
+      "reflexive": "koroself"
+    },
+    {
+      "subject": "ko",
+      "object": "ok",
+      "dependentPossessive": "ra",
+      "independentPossessive": "kra",
+      "reflexive": "okraself"
+    },
+    {
+      "subject": "ko",
+      "object": "yuk",
+      "dependentPossessive": "kon",
+      "independentPossessive": "ukon",
+      "reflexive": "yukonself"
+    },
+    {
+      "subject": "koi",
+      "object": "ik",
+      "dependentPossessive": "ki",
+      "independentPossessive": "ko",
+      "reflexive": "koiself"
+    },
+    {
+      "subject": "kra",
+      "object": "ken",
+      "dependentPossessive": "kras",
+      "independentPossessive": "kras",
+      "reflexive": "kraself"
+    },
+    {
+      "subject": "ku",
+      "object": "kuk",
+      "dependentPossessive": "kui",
+      "independentPossessive": "kuku",
+      "reflexive": "kukuiself"
+    },
+    {
+      "subject": "kui",
+      "object": "kui",
+      "dependentPossessive": "kuiper",
+      "independentPossessive": "kuipers",
+      "reflexive": "kuiself"
+    },
+    {
+      "subject": "kul",
+      "object": "fi",
+      "dependentPossessive": "fis",
+      "independentPossessive": "fis",
+      "reflexive": "kulfiself"
+    },
+    {
+      "subject": "kum",
+      "object": "quat",
+      "dependentPossessive": "quats",
+      "independentPossessive": "quats",
+      "reflexive": "quatself"
+    },
+    {
+      "subject": "kye",
+      "object": "kyne",
+      "dependentPossessive": "kyr",
+      "independentPossessive": "kyrs",
+      "reflexive": "kyrself"
+    },
+    {
+      "subject": "kye",
+      "object": "kyr",
+      "dependentPossessive": "kyr",
+      "independentPossessive": "kyrs",
+      "reflexive": "kyrself"
+    },
+    {
+      "subject": "l",
+      "object": "l",
+      "dependentPossessive": "l’s",
+      "independentPossessive": "l’s",
+      "reflexive": "lself"
+    },
+    {
+      "subject": "la",
+      "object": "al",
+      "dependentPossessive": "alas",
+      "independentPossessive": "alask",
+      "reflexive": "alaskaself"
+    },
+    {
+      "subject": "la",
+      "object": "al",
+      "dependentPossessive": "bor",
+      "independentPossessive": "boran",
+      "reflexive": "alboranself"
+    },
+    {
+      "subject": "la",
+      "object": "al",
+      "dependentPossessive": "hen",
+      "independentPossessive": "hena",
+      "reflexive": "alhenaself"
+    },
+    {
+      "subject": "la",
+      "object": "alg",
+      "dependentPossessive": "gieb",
+      "independentPossessive": "gieba",
+      "reflexive": "algiebaself"
+    },
+    {
+      "subject": "la",
+      "object": "aln",
+      "dependentPossessive": "lam",
+      "independentPossessive": "nilam",
+      "reflexive": "alnilamself"
+    },
+    {
+      "subject": "la",
+      "object": "aln",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nair",
+      "reflexive": "alnairself"
+    },
+    {
+      "subject": "la",
+      "object": "alph",
+      "dependentPossessive": "phard",
+      "independentPossessive": "phard",
+      "reflexive": "alphardself"
+    },
+    {
+      "subject": "la",
+      "object": "alph",
+      "dependentPossessive": "ratz",
+      "independentPossessive": "ratz",
+      "reflexive": "alpheratzself"
+    },
+    {
+      "subject": "la",
+      "object": "alt",
+      "dependentPossessive": "tir",
+      "independentPossessive": "tair",
+      "reflexive": "altairself"
+    },
+    {
+      "subject": "la",
+      "object": "isle",
+      "dependentPossessive": "lan",
+      "independentPossessive": "islan",
+      "reflexive": "islandself"
+    },
+    {
+      "subject": "la",
+      "object": "lac",
+      "dependentPossessive": "di",
+      "independentPossessive": "div",
+      "reflexive": "laccadiveself"
+    },
+    {
+      "subject": "la",
+      "object": "lad",
+      "dependentPossessive": "dy",
+      "independentPossessive": "ady",
+      "reflexive": "ladyself"
+    },
+    {
+      "subject": "la",
+      "object": "lak",
+      "dependentPossessive": "lae",
+      "independentPossessive": "lake",
+      "reflexive": "lakeself"
+    },
+    {
+      "subject": "la",
+      "object": "lak",
+      "dependentPossessive": "lar",
+      "independentPossessive": "lark",
+      "reflexive": "larkself"
+    },
+    {
+      "subject": "la",
+      "object": "lam",
+      "dependentPossessive": "lamd",
+      "independentPossessive": "lambda",
+      "reflexive": "lambdaself"
+    },
+    {
+      "subject": "la",
+      "object": "lamia",
+      "dependentPossessive": "mias",
+      "independentPossessive": "mias",
+      "reflexive": "lamiaself"
+    },
+    {
+      "subject": "la",
+      "object": "lap",
+      "dependentPossessive": "te",
+      "independentPossessive": "tev",
+      "reflexive": "laptevself"
+    },
+    {
+      "subject": "la",
+      "object": "lar",
+      "dependentPossessive": "lars",
+      "independentPossessive": "larsen",
+      "reflexive": "larsenself"
+    },
+    {
+      "subject": "la",
+      "object": "lase",
+      "dependentPossessive": "laser",
+      "independentPossessive": "lasers",
+      "reflexive": "laserself"
+    },
+    {
+      "subject": "la",
+      "object": "ok",
+      "dependentPossessive": "om",
+      "independentPossessive": "oma",
+      "reflexive": "oklahomaself"
+    },
+    {
+      "subject": "lae",
+      "object": "lace",
+      "dependentPossessive": "las",
+      "independentPossessive": "las",
+      "reflexive": "laceself"
+    },
+    {
+      "subject": "lau",
+      "object": "rel",
+      "dependentPossessive": "aur",
+      "independentPossessive": "laur",
+      "reflexive": "laurelself"
+    },
+    {
+      "subject": "lav",
+      "object": "lav",
+      "dependentPossessive": "lavs",
+      "independentPossessive": "lavs",
+      "reflexive": "lavself"
+    },
+    {
+      "subject": "lav",
+      "object": "laven",
+      "dependentPossessive": "lavend",
+      "independentPossessive": "lavends",
+      "reflexive": "lavendself"
+    },
+    {
+      "subject": "le",
+      "object": "al",
+      "dependentPossessive": "ber",
+      "independentPossessive": "berta",
+      "reflexive": "albertaself"
+    },
+    {
+      "subject": "le",
+      "object": "lel",
+      "dependentPossessive": "el",
+      "independentPossessive": "elm",
+      "reflexive": "elmself"
+    },
+    {
+      "subject": "le",
+      "object": "lem",
+      "dependentPossessive": "les",
+      "independentPossessive": "les",
+      "reflexive": "lesself"
+    },
+    {
+      "subject": "le",
+      "object": "lev",
+      "dependentPossessive": "van",
+      "independentPossessive": "vant",
+      "reflexive": "levantineself"
+    },
+    {
+      "subject": "le",
+      "object": "lim",
+      "dependentPossessive": "lir",
+      "independentPossessive": "lirs",
+      "reflexive": "lirself"
+    },
+    {
+      "subject": "le",
+      "object": "via",
+      "dependentPossessive": "vias",
+      "independentPossessive": "vias",
+      "reflexive": "leviaself"
+    },
+    {
+      "subject": "lem",
+      "object": "lem",
+      "dependentPossessive": "lems",
+      "independentPossessive": "lems",
+      "reflexive": "lemself"
+    },
+    {
+      "subject": "lem",
+      "object": "lemon",
+      "dependentPossessive": "lemons",
+      "independentPossessive": "lemons",
+      "reflexive": "lemonself"
+    },
+    {
+      "subject": "lemon",
+      "object": "drop",
+      "dependentPossessive": "lems",
+      "independentPossessive": "lems",
+      "reflexive": "lemondropself"
+    },
+    {
+      "subject": "levia",
+      "object": "than",
+      "dependentPossessive": "vias",
+      "independentPossessive": "vias",
+      "reflexive": "leviaself"
+    },
+    {
+      "subject": "li",
+      "object": "al",
+      "dependentPossessive": "alli",
+      "independentPossessive": "allig",
+      "reflexive": "alligatorself"
+    },
+    {
+      "subject": "li",
+      "object": "al",
+      "dependentPossessive": "oth",
+      "independentPossessive": "oth",
+      "reflexive": "aliothself"
+    },
+    {
+      "subject": "li",
+      "object": "lich",
+      "dependentPossessive": "lis",
+      "independentPossessive": "lichs",
+      "reflexive": "lichself"
+    },
+    {
+      "subject": "li",
+      "object": "lif",
+      "dependentPossessive": "life",
+      "independentPossessive": "lives",
+      "reflexive": "lifeself"
+    },
+    {
+      "subject": "li",
+      "object": "lig",
+      "dependentPossessive": "eg",
+      "independentPossessive": "ege",
+      "reflexive": "liegeself"
+    },
+    {
+      "subject": "li",
+      "object": "lig",
+      "dependentPossessive": "gur",
+      "independentPossessive": "guri",
+      "reflexive": "ligurianself"
+    },
+    {
+      "subject": "li",
+      "object": "lilac",
+      "dependentPossessive": "lile",
+      "independentPossessive": "lila",
+      "reflexive": "lilacself"
+    },
+    {
+      "subject": "li",
+      "object": "lin",
+      "dependentPossessive": "lini",
+      "independentPossessive": "linen",
+      "reflexive": "linenself"
+    },
+    {
+      "subject": "li",
+      "object": "lisp",
+      "dependentPossessive": "lis",
+      "independentPossessive": "lis",
+      "reflexive": "lispself"
+    },
+    {
+      "subject": "lico",
+      "object": "rice",
+      "dependentPossessive": "licos",
+      "independentPossessive": "licos",
+      "reflexive": "licoself"
+    },
+    {
+      "subject": "lim",
+      "object": "lime",
+      "dependentPossessive": "limes",
+      "independentPossessive": "limes",
+      "reflexive": "limeself"
+    },
+    {
+      "subject": "lind",
+      "object": "wurm",
+      "dependentPossessive": "wur",
+      "independentPossessive": "wurs",
+      "reflexive": "lindself"
+    },
+    {
+      "subject": "lind",
+      "object": "wyrm",
+      "dependentPossessive": "wyr",
+      "independentPossessive": "wyrs",
+      "reflexive": "lindself"
+    },
+    {
+      "subject": "liquo",
+      "object": "rice",
+      "dependentPossessive": "liquos",
+      "independentPossessive": "liquos",
+      "reflexive": "liquoself"
+    },
+    {
+      "subject": "lo",
+      "object": "lal",
+      "dependentPossessive": "loy",
+      "independentPossessive": "loya",
+      "reflexive": "loyalself"
+    },
+    {
+      "subject": "lo",
+      "object": "local",
+      "dependentPossessive": "locs",
+      "independentPossessive": "locs",
+      "reflexive": "localself"
+    },
+    {
+      "subject": "lo",
+      "object": "long",
+      "dependentPossessive": "los",
+      "independentPossessive": "longs",
+      "reflexive": "longself"
+    },
+    {
+      "subject": "lo",
+      "object": "loon",
+      "dependentPossessive": "lu",
+      "independentPossessive": "lou",
+      "reflexive": "loonself"
+    },
+    {
+      "subject": "lo",
+      "object": "loop",
+      "dependentPossessive": "los",
+      "independentPossessive": "loops",
+      "reflexive": "loopself"
+    },
+    {
+      "subject": "lo",
+      "object": "lor",
+      "dependentPossessive": "od",
+      "independentPossessive": "ord",
+      "reflexive": "lordself"
+    },
+    {
+      "subject": "lo",
+      "object": "lot",
+      "dependentPossessive": "lotu",
+      "independentPossessive": "lotus",
+      "reflexive": "lotuself"
+    },
+    {
+      "subject": "lon",
+      "object": "gan",
+      "dependentPossessive": "lons",
+      "independentPossessive": "gans",
+      "reflexive": "lonself"
+    },
+    {
+      "subject": "love",
+      "object": "love",
+      "dependentPossessive": "loves",
+      "independentPossessive": "loves",
+      "reflexive": "loveself"
+    },
+    {
+      "subject": "lu",
+      "object": "il",
+      "dependentPossessive": "lus",
+      "independentPossessive": "lusi",
+      "reflexive": "illuself"
+    },
+    {
+      "subject": "lu",
+      "object": "luce",
+      "dependentPossessive": "luck",
+      "independentPossessive": "lucky",
+      "reflexive": "luckself"
+    },
+    {
+      "subject": "lu",
+      "object": "lucid",
+      "dependentPossessive": "luc",
+      "independentPossessive": "luci",
+      "reflexive": "lucidself"
+    },
+    {
+      "subject": "lulla",
+      "object": "by",
+      "dependentPossessive": "lulls",
+      "independentPossessive": "lulls",
+      "reflexive": "lullself"
+    },
+    {
+      "subject": "lulla",
+      "object": "bye",
+      "dependentPossessive": "lulls",
+      "independentPossessive": "lulls",
+      "reflexive": "lullself"
+    },
+    {
+      "subject": "ly",
+      "object": "chee",
+      "dependentPossessive": "lys",
+      "independentPossessive": "chees",
+      "reflexive": "lyself"
+    },
+    {
+      "subject": "ly",
+      "object": "lyr",
+      "dependentPossessive": "lyri",
+      "independentPossessive": "lyric",
+      "reflexive": "lyricself"
+    },
+    {
+      "subject": "m",
+      "object": "m",
+      "dependentPossessive": "m’s",
+      "independentPossessive": "m’s",
+      "reflexive": "mself"
+    },
+    {
+      "subject": "ma",
+      "object": "gen",
+      "dependentPossessive": "mag",
+      "independentPossessive": "magen",
+      "reflexive": "magentaself"
+    },
+    {
+      "subject": "ma",
+      "object": "mag",
+      "dependentPossessive": "nol",
+      "independentPossessive": "nolia",
+      "reflexive": "magnoliaself"
+    },
+    {
+      "subject": "ma",
+      "object": "maine",
+      "dependentPossessive": "ai",
+      "independentPossessive": "aine",
+      "reflexive": "maineself"
+    },
+    {
+      "subject": "ma",
+      "object": "malach",
+      "dependentPossessive": "mala",
+      "independentPossessive": "malachi",
+      "reflexive": "malachiself"
+    },
+    {
+      "subject": "ma",
+      "object": "mar",
+      "dependentPossessive": "ara",
+      "independentPossessive": "mara",
+      "reflexive": "marmarasel"
+    },
+    {
+      "subject": "ma",
+      "object": "mar",
+      "dependentPossessive": "mar",
+      "independentPossessive": "marb",
+      "reflexive": "marbleself"
+    },
+    {
+      "subject": "ma",
+      "object": "mar",
+      "dependentPossessive": "marjor",
+      "independentPossessive": "marjoram",
+      "reflexive": "marjoramself"
+    },
+    {
+      "subject": "ma",
+      "object": "mar",
+      "dependentPossessive": "ryl",
+      "independentPossessive": "rylan",
+      "reflexive": "marylandself"
+    },
+    {
+      "subject": "ma",
+      "object": "tob",
+      "dependentPossessive": "nit",
+      "independentPossessive": "nito",
+      "reflexive": "manitobaself"
+    },
+    {
+      "subject": "maca",
+      "object": "puno",
+      "dependentPossessive": "punos",
+      "independentPossessive": "punos",
+      "reflexive": "macapunoself"
+    },
+    {
+      "subject": "maca",
+      "object": "ron",
+      "dependentPossessive": "rons",
+      "independentPossessive": "rons",
+      "reflexive": "macaronself"
+    },
+    {
+      "subject": "maca",
+      "object": "roon",
+      "dependentPossessive": "roons",
+      "independentPossessive": "roons",
+      "reflexive": "macaroonself"
+    },
+    {
+      "subject": "mae",
+      "object": "mae",
+      "dependentPossessive": "mair",
+      "independentPossessive": "maes",
+      "reflexive": "maeself"
+    },
+    {
+      "subject": "mae",
+      "object": "map",
+      "dependentPossessive": "pel",
+      "independentPossessive": "aple",
+      "reflexive": "mapleself"
+    },
+    {
       "subject": "mae",
       "object": "mare",
       "dependentPossessive": "mare",
       "independentPossessive": "mares",
       "reflexive": "mareself"
+    },
+    {
+      "subject": "mag",
+      "object": "magne",
+      "dependentPossessive": "magni",
+      "independentPossessive": "magnet",
+      "reflexive": "magneself"
+    },
+    {
+      "subject": "mai",
+      "object": "im",
+      "dependentPossessive": "magi",
+      "independentPossessive": "magin",
+      "reflexive": "imagineself"
+    },
+    {
+      "subject": "mai",
+      "object": "main",
+      "dependentPossessive": "mais",
+      "independentPossessive": "mains",
+      "reflexive": "mainself"
+    },
+    {
+      "subject": "man",
+      "object": "drake",
+      "dependentPossessive": "drakes",
+      "independentPossessive": "drakes",
+      "reflexive": "mandrakeself"
+    },
+    {
+      "subject": "manda",
+      "object": "rine",
+      "dependentPossessive": "rines",
+      "independentPossessive": "rines",
+      "reflexive": "rineself"
+    },
+    {
+      "subject": "mandra",
+      "object": "gora",
+      "dependentPossessive": "gor",
+      "independentPossessive": "gors",
+      "reflexive": "mandraself"
+    },
+    {
+      "subject": "mango",
+      "object": "steen",
+      "dependentPossessive": "steens",
+      "independentPossessive": "steens",
+      "reflexive": "steenself"
+    },
+    {
+      "subject": "manti",
+      "object": "core",
+      "dependentPossessive": "core",
+      "independentPossessive": "cores",
+      "reflexive": "coreself"
+    },
+    {
+      "subject": "mar",
+      "object": "march",
+      "dependentPossessive": "mars",
+      "independentPossessive": "mars",
+      "reflexive": "marchself"
+    },
+    {
+      "subject": "marc",
+      "object": "mar",
+      "dependentPossessive": "marcas",
+      "independentPossessive": "marcas",
+      "reflexive": "marcaself"
+    },
+    {
+      "subject": "mari",
+      "object": "maripo",
+      "dependentPossessive": "maripos",
+      "independentPossessive": "mariposa",
+      "reflexive": "maripoself"
+    },
+    {
+      "subject": "marma",
+      "object": "lade",
+      "dependentPossessive": "marmas",
+      "independentPossessive": "marmas",
+      "reflexive": "marmaself"
+    },
+    {
+      "subject": "marsh",
+      "object": "mallow",
+      "dependentPossessive": "lows",
+      "independentPossessive": "lows",
+      "reflexive": "marshself"
+    },
+    {
+      "subject": "marzi",
+      "object": "pan",
+      "dependentPossessive": "mar",
+      "independentPossessive": "marz",
+      "reflexive": "marziself"
+    },
+    {
+      "subject": "me",
+      "object": "med",
+      "dependentPossessive": "medit",
+      "independentPossessive": "medita",
+      "reflexive": "meditateself"
+    },
+    {
+      "subject": "mea",
+      "object": "meane",
+      "dependentPossessive": "meas",
+      "independentPossessive": "meas",
+      "reflexive": "meaneself"
+    },
+    {
+      "subject": "med",
+      "object": "ley",
+      "dependentPossessive": "leys",
+      "independentPossessive": "leys",
+      "reflexive": "leyself"
+    },
+    {
+      "subject": "mel",
+      "object": "melon",
+      "dependentPossessive": "melo",
+      "independentPossessive": "melons",
+      "reflexive": "melonself"
+    },
+    {
+      "subject": "melo",
+      "object": "dy",
+      "dependentPossessive": "dys",
+      "independentPossessive": "dys",
+      "reflexive": "meloself"
+    },
+    {
+      "subject": "mer",
+      "object": "ringue",
+      "dependentPossessive": "ringues",
+      "independentPossessive": "ringues",
+      "reflexive": "ringueself"
+    },
+    {
+      "subject": "met",
+      "object": "mett",
+      "dependentPossessive": "mettas",
+      "independentPossessive": "mettas",
+      "reflexive": "mettaself"
+    },
+    {
+      "subject": "mete",
+      "object": "mete",
+      "dependentPossessive": "meteor",
+      "independentPossessive": "meteor",
+      "reflexive": "meteself"
+    },
+    {
+      "subject": "metro",
+      "object": "nome",
+      "dependentPossessive": "nomes",
+      "independentPossessive": "nomes",
+      "reflexive": "metronomeself"
+    },
+    {
+      "subject": "mew",
+      "object": "meow",
+      "dependentPossessive": "rowr",
+      "independentPossessive": "rowrs",
+      "reflexive": "meowself"
+    },
+    {
+      "subject": "mey",
+      "object": "mesa",
+      "dependentPossessive": "mes",
+      "independentPossessive": "mesas",
+      "reflexive": "mesaself"
+    },
+    {
+      "subject": "mezz",
+      "object": "mezzo",
+      "dependentPossessive": "mezz",
+      "independentPossessive": "mezzes",
+      "reflexive": "mezzoself"
+    },
+    {
+      "subject": "mi",
+      "object": "ip",
+      "dependentPossessive": "iss",
+      "independentPossessive": "issi",
+      "reflexive": "mississipiself"
+    },
+    {
+      "subject": "mi",
+      "object": "med",
+      "dependentPossessive": "dit",
+      "independentPossessive": "diter",
+      "reflexive": "mediterraneanself"
+    },
+    {
+      "subject": "mi",
+      "object": "mem",
+      "dependentPossessive": "memor",
+      "independentPossessive": "memor",
+      "reflexive": "memoryself"
+    },
+    {
+      "subject": "mi",
+      "object": "menk",
+      "dependentPossessive": "ken",
+      "independentPossessive": "kent",
+      "reflexive": "menkentself"
+    },
+    {
+      "subject": "mi",
+      "object": "menk",
+      "dependentPossessive": "lin",
+      "independentPossessive": "linan",
+      "reflexive": "menkalinanself"
+    },
+    {
+      "subject": "mi",
+      "object": "mich",
+      "dependentPossessive": "michi",
+      "independentPossessive": "michig",
+      "reflexive": "michiganself"
+    },
+    {
+      "subject": "mi",
+      "object": "mid",
+      "dependentPossessive": "ay",
+      "independentPossessive": "way",
+      "reflexive": "midwayself"
+    },
+    {
+      "subject": "mi",
+      "object": "mid",
+      "dependentPossessive": "mis",
+      "independentPossessive": "mids",
+      "reflexive": "midself"
+    },
+    {
+      "subject": "mi",
+      "object": "midi",
+      "dependentPossessive": "mids",
+      "independentPossessive": "midis",
+      "reflexive": "midiself"
+    },
+    {
+      "subject": "mi",
+      "object": "mim",
+      "dependentPossessive": "sa",
+      "independentPossessive": "osa",
+      "reflexive": "mimosaself"
+    },
+    {
+      "subject": "mi",
+      "object": "min",
+      "dependentPossessive": "dan",
+      "independentPossessive": "danao",
+      "reflexive": "mindanaoself"
+    },
+    {
+      "subject": "mi",
+      "object": "min",
+      "dependentPossessive": "so",
+      "independentPossessive": "sot",
+      "reflexive": "minnesotaself"
+    },
+    {
+      "subject": "mi",
+      "object": "mir",
+      "dependentPossessive": "cul",
+      "independentPossessive": "culou",
+      "reflexive": "miraculouself"
+    },
+    {
+      "subject": "mi",
+      "object": "mir",
+      "dependentPossessive": "fa",
+      "independentPossessive": "fak",
+      "reflexive": "mirfakself"
+    },
+    {
+      "subject": "mi",
+      "object": "mir",
+      "dependentPossessive": "irro",
+      "independentPossessive": "irror",
+      "reflexive": "mirrorself"
+    },
+    {
+      "subject": "mi",
+      "object": "mir",
+      "dependentPossessive": "rach",
+      "independentPossessive": "ach",
+      "reflexive": "mirachself"
+    },
+    {
+      "subject": "mi",
+      "object": "mir",
+      "dependentPossessive": "za",
+      "independentPossessive": "zam",
+      "reflexive": "mirzamself"
+    },
+    {
+      "subject": "mi",
+      "object": "myth",
+      "dependentPossessive": "myths",
+      "independentPossessive": "mythos",
+      "reflexive": "mythself"
+    },
+    {
+      "subject": "mi",
+      "object": "or",
+      "dependentPossessive": "mis",
+      "independentPossessive": "missou",
+      "reflexive": "missouriself"
+    },
+    {
+      "subject": "mie",
+      "object": "mem",
+      "dependentPossessive": "mer",
+      "independentPossessive": "mers",
+      "reflexive": "memself"
+    },
+    {
+      "subject": "mim",
+      "object": "mic",
+      "dependentPossessive": "mims",
+      "independentPossessive": "mics",
+      "reflexive": "mimself"
+    },
+    {
+      "subject": "mim",
+      "object": "mim",
+      "dependentPossessive": "myr",
+      "independentPossessive": "myrs",
+      "reflexive": "mimself"
+    },
+    {
+      "subject": "min",
+      "object": "mint",
+      "dependentPossessive": "mints",
+      "independentPossessive": "mints",
+      "reflexive": "mintself"
+    },
+    {
+      "subject": "min",
+      "object": "nuet",
+      "dependentPossessive": "mins",
+      "independentPossessive": "mins",
+      "reflexive": "minuetself"
+    },
+    {
+      "subject": "mino",
+      "object": "taur",
+      "dependentPossessive": "taur",
+      "independentPossessive": "taurs",
+      "reflexive": "taurself"
+    },
+    {
+      "subject": "mo",
+      "object": "met",
+      "dependentPossessive": "ro",
+      "independentPossessive": "tro",
+      "reflexive": "metroself"
+    },
+    {
+      "subject": "mo",
+      "object": "mod",
+      "dependentPossessive": "moder",
+      "independentPossessive": "modern",
+      "reflexive": "modernself"
+    },
+    {
+      "subject": "mo",
+      "object": "mol",
+      "dependentPossessive": "luc",
+      "independentPossessive": "lucca",
+      "reflexive": "moluccaself"
+    },
+    {
+      "subject": "mo",
+      "object": "mon",
+      "dependentPossessive": "mona",
+      "independentPossessive": "monad",
+      "reflexive": "monadself"
+    },
+    {
+      "subject": "mo",
+      "object": "mon",
+      "dependentPossessive": "mond",
+      "independentPossessive": "monda",
+      "reflexive": "mondayself"
+    },
+    {
+      "subject": "mo",
+      "object": "mon",
+      "dependentPossessive": "tan",
+      "independentPossessive": "tana",
+      "reflexive": "montanaself"
+    },
+    {
+      "subject": "mo",
+      "object": "mor",
+      "dependentPossessive": "morn",
+      "independentPossessive": "morni",
+      "reflexive": "morningself"
+    },
+    {
+      "subject": "mo",
+      "object": "mot",
+      "dependentPossessive": "to",
+      "independentPossessive": "tor",
+      "reflexive": "motorself"
+    },
+    {
+      "subject": "mo",
+      "object": "mov",
+      "dependentPossessive": "mos",
+      "independentPossessive": "movs",
+      "reflexive": "movself"
+    },
+    {
+      "subject": "mo",
+      "object": "tor",
+      "dependentPossessive": "cyl",
+      "independentPossessive": "cyc",
+      "reflexive": "motorcycleself"
+    },
+    {
+      "subject": "moi",
+      "object": "moissan",
+      "dependentPossessive": "moiss",
+      "independentPossessive": "moissa",
+      "reflexive": "moissaniself"
+    },
+    {
+      "subject": "mol",
+      "object": "lasses",
+      "dependentPossessive": "lass",
+      "independentPossessive": "lasses",
+      "reflexive": "molself"
+    },
+    {
+      "subject": "moon",
+      "object": "cake",
+      "dependentPossessive": "cakes",
+      "independentPossessive": "cakes",
+      "reflexive": "mooncakes"
+    },
+    {
+      "subject": "mos",
+      "object": "moss",
+      "dependentPossessive": "mossir",
+      "independentPossessive": "mossirs",
+      "reflexive": "mosself"
+    },
+    {
+      "subject": "mou",
+      "object": "mousse",
+      "dependentPossessive": "mousse",
+      "independentPossessive": "mousses",
+      "reflexive": "mousseself"
+    },
+    {
+      "subject": "mu",
+      "object": "mur",
+      "dependentPossessive": "mus",
+      "independentPossessive": "mus",
+      "reflexive": "muself"
+    },
+    {
+      "subject": "mul",
+      "object": "berry",
+      "dependentPossessive": "berr",
+      "independentPossessive": "berrs",
+      "reflexive": "mulself"
+    },
+    {
+      "subject": "mun",
+      "object": "mun",
+      "dependentPossessive": "munz",
+      "independentPossessive": "munz",
+      "reflexive": "munzself"
+    },
+    {
+      "subject": "mus",
+      "object": "sic",
+      "dependentPossessive": "mus",
+      "independentPossessive": "muses",
+      "reflexive": "musicself"
+    },
+    {
+      "subject": "musc",
+      "object": "musc",
+      "dependentPossessive": "muscas",
+      "independentPossessive": "muscas",
+      "reflexive": "muscaself"
+    },
+    {
+      "subject": "muse",
+      "object": "ette",
+      "dependentPossessive": "ettes",
+      "independentPossessive": "ettes",
+      "reflexive": "etteself"
+    },
+    {
+      "subject": "my",
+      "object": "myr",
+      "dependentPossessive": "tan",
+      "independentPossessive": "toan",
+      "reflexive": "myrtoanself"
+    },
+    {
+      "subject": "mye",
+      "object": "myr",
+      "dependentPossessive": "myr",
+      "independentPossessive": "myrs",
+      "reflexive": "myrself"
+    },
+    {
+      "subject": "n",
+      "object": "n",
+      "dependentPossessive": "n’s",
+      "independentPossessive": "n’s",
+      "reflexive": "nself"
+    },
+    {
+      "subject": "na",
+      "object": "aln",
+      "dependentPossessive": "tak",
+      "independentPossessive": "nitak",
+      "reflexive": "alnitakself"
+    },
+    {
+      "subject": "na",
+      "object": "ant",
+      "dependentPossessive": "ti",
+      "independentPossessive": "tique",
+      "reflexive": "antiqueself"
+    },
+    {
+      "subject": "na",
+      "object": "name",
+      "dependentPossessive": "nas",
+      "independentPossessive": "names",
+      "reflexive": "nameself"
+    },
+    {
+      "subject": "na",
+      "object": "nan",
+      "dependentPossessive": "nan",
+      "independentPossessive": "nan's",
+      "reflexive": "naself"
+    },
+    {
+      "subject": "na",
+      "object": "nath",
+      "dependentPossessive": "ath",
+      "independentPossessive": "ath",
+      "reflexive": "nathself"
+    },
+    {
+      "subject": "na",
+      "object": "naut",
+      "dependentPossessive": "nauti",
+      "independentPossessive": "nautic",
+      "reflexive": "nautself"
+    },
+    {
+      "subject": "na",
+      "object": "nav",
+      "dependentPossessive": "vas",
+      "independentPossessive": "vassa",
+      "reflexive": "navassaself"
+    },
+    {
+      "subject": "na",
+      "object": "nov",
+      "dependentPossessive": "novel",
+      "independentPossessive": "novel",
+      "reflexive": "novelself"
+    },
+    {
+      "subject": "nae",
+      "object": "naem",
+      "dependentPossessive": "naer",
+      "independentPossessive": "naers",
+      "reflexive": "naemself"
+    },
+    {
+      "subject": "nae",
+      "object": "nym",
+      "dependentPossessive": "nyr",
+      "independentPossessive": "nyrs",
+      "reflexive": "nymself"
+    },
+    {
+      "subject": "nap",
+      "object": "napsta",
+      "dependentPossessive": "napstas",
+      "independentPossessive": "napstas",
+      "reflexive": "napstaself"
+    },
+    {
+      "subject": "nar",
+      "object": "narc",
+      "dependentPossessive": "narcir",
+      "independentPossessive": "narcirs",
+      "reflexive": "narcself"
+    },
+    {
+      "subject": "ne",
+      "object": "neb",
+      "dependentPossessive": "ras",
+      "independentPossessive": "rask",
+      "reflexive": "nebraskaself"
+    },
+    {
+      "subject": "ne",
+      "object": "neg",
+      "dependentPossessive": "nega",
+      "independentPossessive": "negat",
+      "reflexive": "negativeself"
+    },
+    {
+      "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "neir",
+      "independentPossessive": "neirs",
+      "reflexive": "nemself"
+    },
+    {
+      "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "nes",
+      "independentPossessive": "nes",
+      "reflexive": "nemself"
+    },
+    {
+      "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "nes",
+      "independentPossessive": "nes",
+      "reflexive": "neself"
     },
     {
       "subject": "ne",
@@ -157,10 +5477,409 @@
     },
     {
       "subject": "ne",
+      "object": "nem",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nirs",
+      "reflexive": "nirself"
+    },
+    {
+      "subject": "ne",
+      "object": "nen",
+      "dependentPossessive": "en",
+      "independentPossessive": "ene",
+      "reflexive": "neneself"
+    },
+    {
+      "subject": "ne",
+      "object": "neo",
+      "dependentPossessive": "neodym",
+      "independentPossessive": "neode",
+      "reflexive": "neodymself"
+    },
+    {
+      "subject": "ne",
+      "object": "ner",
+      "dependentPossessive": "neir",
+      "independentPossessive": "neirs",
+      "reflexive": "neirself"
+    },
+    {
+      "subject": "ne",
+      "object": "ner",
+      "dependentPossessive": "nerre",
+      "independentPossessive": "nerse",
+      "reflexive": "nerself"
+    },
+    {
+      "subject": "ne",
+      "object": "ner",
+      "dependentPossessive": "nev",
+      "independentPossessive": "nerve",
+      "reflexive": "nerveself"
+    },
+    {
+      "subject": "ne",
       "object": "ner",
       "dependentPossessive": "nis",
       "independentPossessive": "nis",
       "reflexive": "nemself"
+    },
+    {
+      "subject": "ne",
+      "object": "nev",
+      "dependentPossessive": "ad",
+      "independentPossessive": "vad",
+      "reflexive": "nevadaself"
+    },
+    {
+      "subject": "ne",
+      "object": "nim",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nirs",
+      "reflexive": "nimself"
+    },
+    {
+      "subject": "ne",
+      "object": "nim",
+      "dependentPossessive": "nis",
+      "independentPossessive": "nis",
+      "reflexive": "nimself"
+    },
+    {
+      "subject": "ne",
+      "object": "nir",
+      "dependentPossessive": "nir",
+      "independentPossessive": "nirs",
+      "reflexive": "nirself"
+    },
+    {
+      "subject": "ne",
+      "object": "nym",
+      "dependentPossessive": "nyr",
+      "independentPossessive": "nyrs",
+      "reflexive": "nymself"
+    },
+    {
+      "subject": "nect",
+      "object": "nectar",
+      "dependentPossessive": "nectar",
+      "independentPossessive": "nectars",
+      "reflexive": "nectarself"
+    },
+    {
+      "subject": "necta",
+      "object": "rine",
+      "dependentPossessive": "nectar",
+      "independentPossessive": "nectars",
+      "reflexive": "nectarself"
+    },
+    {
+      "subject": "nee",
+      "object": "needle",
+      "dependentPossessive": "dles",
+      "independentPossessive": "dles",
+      "reflexive": "needleself"
+    },
+    {
+      "subject": "ni",
+      "object": "an",
+      "dependentPossessive": "anise",
+      "independentPossessive": "anise",
+      "reflexive": "aniself"
+    },
+    {
+      "subject": "ni",
+      "object": "mid",
+      "dependentPossessive": "midin",
+      "independentPossessive": "midni",
+      "reflexive": "midnightself"
+    },
+    {
+      "subject": "ni",
+      "object": "nigh",
+      "dependentPossessive": "night",
+      "independentPossessive": "nights",
+      "reflexive": "nightself"
+    },
+    {
+      "subject": "ni",
+      "object": "nine",
+      "dependentPossessive": "nis",
+      "independentPossessive": "nines",
+      "reflexive": "nineself"
+    },
+    {
+      "subject": "night",
+      "object": "night",
+      "dependentPossessive": "nocturne",
+      "independentPossessive": "nocturnes",
+      "reflexive": "nightself"
+    },
+    {
+      "subject": "no",
+      "object": "non",
+      "dependentPossessive": "nona",
+      "independentPossessive": "nonad",
+      "reflexive": "nonadself"
+    },
+    {
+      "subject": "no",
+      "object": "north",
+      "dependentPossessive": "or",
+      "independentPossessive": "nor",
+      "reflexive": "northself"
+    },
+    {
+      "subject": "noc",
+      "object": "turne",
+      "dependentPossessive": "nocs",
+      "independentPossessive": "nocs",
+      "reflexive": "turneself"
+    },
+    {
+      "subject": "non",
+      "object": "et",
+      "dependentPossessive": "nons",
+      "independentPossessive": "nons",
+      "reflexive": "nonetself"
+    },
+    {
+      "subject": "nou",
+      "object": "gat",
+      "dependentPossessive": "gats",
+      "independentPossessive": "gats",
+      "reflexive": "nougatself"
+    },
+    {
+      "subject": "nou",
+      "object": "noun",
+      "dependentPossessive": "nu",
+      "independentPossessive": "nou",
+      "reflexive": "nounself"
+    },
+    {
+      "subject": "nu",
+      "object": "noon",
+      "dependentPossessive": "noons",
+      "independentPossessive": "noons",
+      "reflexive": "noonself"
+    },
+    {
+      "subject": "nu",
+      "object": "num",
+      "dependentPossessive": "nus",
+      "independentPossessive": "nus",
+      "reflexive": "nuself"
+    },
+    {
+      "subject": "nu",
+      "object": "nun",
+      "dependentPossessive": "vut",
+      "independentPossessive": "avut",
+      "reflexive": "nunavutself"
+    },
+    {
+      "subject": "nu",
+      "object": "nunk",
+      "dependentPossessive": "ki",
+      "independentPossessive": "ki",
+      "reflexive": "nunkiself"
+    },
+    {
+      "subject": "ny",
+      "object": "nym",
+      "dependentPossessive": "nys",
+      "independentPossessive": "nys",
+      "reflexive": "nymself"
+    },
+    {
+      "subject": "nym",
+      "object": "nym",
+      "dependentPossessive": "nyms",
+      "independentPossessive": "nyms",
+      "reflexive": "nymself"
+    },
+    {
+      "subject": "o",
+      "object": "live",
+      "dependentPossessive": "lives",
+      "independentPossessive": "lives",
+      "reflexive": "oliveself"
+    },
+    {
+      "subject": "o",
+      "object": "o",
+      "dependentPossessive": "o’s",
+      "independentPossessive": "o’s",
+      "reflexive": "oself"
+    },
+    {
+      "subject": "o",
+      "object": "oct",
+      "dependentPossessive": "octa",
+      "independentPossessive": "octad",
+      "reflexive": "octadself"
+    },
+    {
+      "subject": "o",
+      "object": "oh",
+      "dependentPossessive": "hi",
+      "independentPossessive": "hio",
+      "reflexive": "ohioself"
+    },
+    {
+      "subject": "o",
+      "object": "orc",
+      "dependentPossessive": "or",
+      "independentPossessive": "orcs",
+      "reflexive": "orcself"
+    },
+    {
+      "subject": "o",
+      "object": "os",
+      "dependentPossessive": "orbs",
+      "independentPossessive": "o",
+      "reflexive": "orbself"
+    },
+    {
+      "subject": "o",
+      "object": "pera",
+      "dependentPossessive": "per",
+      "independentPossessive": "peras",
+      "reflexive": "operaself"
+    },
+    {
+      "subject": "o",
+      "object": "pus",
+      "dependentPossessive": "os",
+      "independentPossessive": "os",
+      "reflexive": "opuself"
+    },
+    {
+      "subject": "ob",
+      "object": "object",
+      "dependentPossessive": "obs",
+      "independentPossessive": "objects",
+      "reflexive": "objectself"
+    },
+    {
+      "subject": "ob",
+      "object": "objective",
+      "dependentPossessive": "objects",
+      "independentPossessive": "objects",
+      "reflexive": "objectiveself"
+    },
+    {
+      "subject": "oc",
+      "object": "tet",
+      "dependentPossessive": "octs",
+      "independentPossessive": "octs",
+      "reflexive": "octetself"
+    },
+    {
+      "subject": "ocean",
+      "object": "ocean",
+      "dependentPossessive": "oceans",
+      "independentPossessive": "oceans",
+      "reflexive": "oceanself"
+    },
+    {
+      "subject": "ode",
+      "object": "ode",
+      "dependentPossessive": "odes",
+      "independentPossessive": "odes",
+      "reflexive": "odeself"
+    },
+    {
+      "subject": "om",
+      "object": "ome",
+      "dependentPossessive": "omeg",
+      "independentPossessive": "omega",
+      "reflexive": "omegaself"
+    },
+    {
+      "subject": "om",
+      "object": "omic",
+      "dependentPossessive": "omi",
+      "independentPossessive": "omicron",
+      "reflexive": "omicronself"
+    },
+    {
+      "subject": "one",
+      "object": "one",
+      "dependentPossessive": "ones",
+      "independentPossessive": "ones",
+      "reflexive": "oneself"
+    },
+    {
+      "subject": "one",
+      "object": "one",
+      "dependentPossessive": "one’s",
+      "independentPossessive": "ones",
+      "reflexive": "oneself"
+    },
+    {
+      "subject": "oort",
+      "object": "oort",
+      "dependentPossessive": "oort",
+      "independentPossessive": "oorts",
+      "reflexive": "oortself"
+    },
+    {
+      "subject": "oprett",
+      "object": "pretta",
+      "dependentPossessive": "pretts",
+      "independentPossessive": "pretts",
+      "reflexive": "oprettaself"
+    },
+    {
+      "subject": "or",
+      "object": "or",
+      "dependentPossessive": "orion",
+      "independentPossessive": "orions",
+      "reflexive": "orself"
+    },
+    {
+      "subject": "or",
+      "object": "ora",
+      "dependentPossessive": "oran",
+      "independentPossessive": "orans",
+      "reflexive": "orangeself"
+    },
+    {
+      "subject": "or",
+      "object": "orn",
+      "dependentPossessive": "orna",
+      "independentPossessive": "ornas",
+      "reflexive": "ornaself"
+    },
+    {
+      "subject": "oran",
+      "object": "orange",
+      "dependentPossessive": "orans",
+      "independentPossessive": "orans",
+      "reflexive": "orangeself"
+    },
+    {
+      "subject": "ore",
+      "object": "oreo",
+      "dependentPossessive": "ore",
+      "independentPossessive": "ores",
+      "reflexive": "oreoself"
+    },
+    {
+      "subject": "ori",
+      "object": "or",
+      "dependentPossessive": "rol",
+      "independentPossessive": "riole",
+      "reflexive": "orioleself"
+    },
+    {
+      "subject": "oshe",
+      "object": "osh",
+      "dependentPossessive": "ocen",
+      "independentPossessive": "ocean",
+      "reflexive": "oceanself"
     },
     {
       "subject": "ou",
@@ -170,11 +5889,333 @@
       "reflexive": "ouself"
     },
     {
+      "subject": "oue",
+      "object": "vre",
+      "dependentPossessive": "vres",
+      "independentPossessive": "vres",
+      "reflexive": "vreself"
+    },
+    {
+      "subject": "out",
+      "object": "out",
+      "dependentPossessive": "outs",
+      "independentPossessive": "outs",
+      "reflexive": "outself"
+    },
+    {
+      "subject": "out",
+      "object": "output",
+      "dependentPossessive": "outs",
+      "independentPossessive": "outputs",
+      "reflexive": "outputself"
+    },
+    {
+      "subject": "over",
+      "object": "ture",
+      "dependentPossessive": "ture",
+      "independentPossessive": "tures",
+      "reflexive": "overtureself"
+    },
+    {
+      "subject": "p",
+      "object": "p",
+      "dependentPossessive": "p’s",
+      "independentPossessive": "p’s",
+      "reflexive": "pself"
+    },
+    {
+      "subject": "pa",
+      "object": "cif",
+      "dependentPossessive": "pac",
+      "independentPossessive": "pacif",
+      "reflexive": "pacificself"
+    },
+    {
+      "subject": "pa",
+      "object": "pal",
+      "dependentPossessive": "al",
+      "independentPossessive": "alm",
+      "reflexive": "palmself"
+    },
+    {
+      "subject": "pa",
+      "object": "pan",
+      "dependentPossessive": "ce",
+      "independentPossessive": "cea",
+      "reflexive": "panaceaself"
+    },
+    {
+      "subject": "pa",
+      "object": "pap",
+      "dependentPossessive": "paper",
+      "independentPossessive": "pas",
+      "reflexive": "paperself"
+    },
+    {
+      "subject": "pa",
+      "object": "par",
+      "dependentPossessive": "pari",
+      "independentPossessive": "pariet",
+      "reflexive": "parietalself"
+    },
+    {
+      "subject": "pa",
+      "object": "par",
+      "dependentPossessive": "pars",
+      "independentPossessive": "pars",
+      "reflexive": "parsleyself"
+    },
+    {
+      "subject": "pa",
+      "object": "pastel",
+      "dependentPossessive": "pas",
+      "independentPossessive": "past",
+      "reflexive": "pastelself"
+    },
+    {
+      "subject": "pa",
+      "object": "pat",
+      "dependentPossessive": "pas",
+      "independentPossessive": "past",
+      "reflexive": "pastself"
+    },
+    {
+      "subject": "pa",
+      "object": "pavo",
+      "dependentPossessive": "pav",
+      "independentPossessive": "pavonis",
+      "reflexive": "pavoself"
+    },
+    {
+      "subject": "pa",
+      "object": "paya",
+      "dependentPossessive": "pas",
+      "independentPossessive": "payas",
+      "reflexive": "payaself"
+    },
+    {
+      "subject": "pachy",
+      "object": "cereus",
+      "dependentPossessive": "cer",
+      "independentPossessive": "cereus",
+      "reflexive": "pachyself"
+    },
+    {
+      "subject": "pae",
+      "object": "an",
+      "dependentPossessive": "ans",
+      "independentPossessive": "ans",
+      "reflexive": "paeanself"
+    },
+    {
+      "subject": "paint",
+      "object": "painting",
+      "dependentPossessive": "painted",
+      "independentPossessive": "painted",
+      "reflexive": "paintself"
+    },
+    {
+      "subject": "pan",
+      "object": "pan",
+      "dependentPossessive": "pans",
+      "independentPossessive": "pans",
+      "reflexive": "panself"
+    },
+    {
+      "subject": "panna",
+      "object": "cotta",
+      "dependentPossessive": "pannas",
+      "independentPossessive": "cottas",
+      "reflexive": "pannaself"
+    },
+    {
+      "subject": "pap",
+      "object": "papy",
+      "dependentPossessive": "papys",
+      "independentPossessive": "papys",
+      "reflexive": "papyruself"
+    },
+    {
+      "subject": "par",
+      "object": "fait",
+      "dependentPossessive": "par",
+      "independentPossessive": "faits",
+      "reflexive": "parfaitself"
+    },
+    {
+      "subject": "par",
+      "object": "ody",
+      "dependentPossessive": "par",
+      "independentPossessive": "pars",
+      "reflexive": "parself"
+    },
+    {
+      "subject": "par",
+      "object": "paren",
+      "dependentPossessive": "pars",
+      "independentPossessive": "pars",
+      "reflexive": "parenself"
+    },
+    {
+      "subject": "paro",
+      "object": "dia",
+      "dependentPossessive": "par",
+      "independentPossessive": "pars",
+      "reflexive": "parodiaself"
+    },
+    {
+      "subject": "pas",
+      "object": "pastry",
+      "dependentPossessive": "pas",
+      "independentPossessive": "pas",
+      "reflexive": "pastryself"
+    },
+    {
+      "subject": "pass",
+      "object": "sion",
+      "dependentPossessive": "sions",
+      "independentPossessive": "sions",
+      "reflexive": "sionself"
+    },
+    {
+      "subject": "pe",
+      "object": "hen",
+      "dependentPossessive": "ahen",
+      "independentPossessive": "eahen",
+      "reflexive": "peahenself"
+    },
+    {
+      "subject": "pe",
+      "object": "peac",
+      "dependentPossessive": "ock",
+      "independentPossessive": "eaco",
+      "reflexive": "peacockself"
+    },
+    {
+      "subject": "pe",
+      "object": "peaf",
+      "dependentPossessive": "afo",
+      "independentPossessive": "afowl",
+      "reflexive": "peafowlself"
+    },
+    {
+      "subject": "pe",
+      "object": "pech",
+      "dependentPossessive": "chor",
+      "independentPossessive": "chora",
+      "reflexive": "pechoraself"
+    },
+    {
+      "subject": "pe",
+      "object": "pel",
+      "dependentPossessive": "lic",
+      "independentPossessive": "elic",
+      "reflexive": "pelicanself"
+    },
+    {
+      "subject": "pe",
+      "object": "pen",
+      "dependentPossessive": "pens",
+      "independentPossessive": "pencil",
+      "reflexive": "penself"
+    },
+    {
+      "subject": "pe",
+      "object": "pent",
+      "dependentPossessive": "penta",
+      "independentPossessive": "pentad",
+      "reflexive": "pentadself"
+    },
+    {
+      "subject": "pe",
+      "object": "peony",
+      "dependentPossessive": "peo",
+      "independentPossessive": "peon",
+      "reflexive": "peonyself"
+    },
+    {
+      "subject": "pe",
+      "object": "per",
+      "dependentPossessive": "peri",
+      "independentPossessive": "peri",
+      "reflexive": "periself"
+    },
+    {
+      "subject": "pe",
+      "object": "per",
+      "dependentPossessive": "pers",
+      "independentPossessive": "pers",
+      "reflexive": "perself"
+    },
+    {
+      "subject": "pe",
+      "object": "perl",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "perlself"
+    },
+    {
+      "subject": "pe",
+      "object": "yote",
+      "dependentPossessive": "yotes",
+      "independentPossessive": "yotes",
+      "reflexive": "peyoself"
+    },
+    {
+      "subject": "peace",
+      "object": "peace",
+      "dependentPossessive": "peaces",
+      "independentPossessive": "peaces",
+      "reflexive": "peacelf"
+    },
+    {
+      "subject": "peach",
+      "object": "peach",
+      "dependentPossessive": "peaches",
+      "independentPossessive": "peaches",
+      "reflexive": "peachself"
+    },
+    {
+      "subject": "pear",
+      "object": "pear",
+      "dependentPossessive": "pears",
+      "independentPossessive": "pears",
+      "reflexive": "pearself"
+    },
+    {
+      "subject": "peg",
+      "object": "pega",
+      "dependentPossessive": "pegs",
+      "independentPossessive": "pegas",
+      "reflexive": "pegaself"
+    },
+    {
       "subject": "peh",
       "object": "pehm",
       "dependentPossessive": "peh's",
       "independentPossessive": "peh's",
       "reflexive": "pehself"
+    },
+    {
+      "subject": "pen",
+      "object": "pend",
+      "dependentPossessive": "pendu",
+      "independentPossessive": "pend",
+      "reflexive": "penduself"
+    },
+    {
+      "subject": "penn",
+      "object": "syl",
+      "dependentPossessive": "va",
+      "independentPossessive": "nia",
+      "reflexive": "pennsylvaniaself"
+    },
+    {
+      "subject": "per",
+      "object": "form",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "performself"
     },
     {
       "subject": "per",
@@ -184,11 +6225,221 @@
       "reflexive": "perself"
     },
     {
+      "subject": "per",
+      "object": "simm",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "persimself"
+    },
+    {
       "subject": "person",
       "object": "per",
       "dependentPossessive": "per",
       "independentPossessive": "pers",
       "reflexive": "perself"
+    },
+    {
+      "subject": "pery",
+      "object": "ton",
+      "dependentPossessive": "tons",
+      "independentPossessive": "tons",
+      "reflexive": "peryself"
+    },
+    {
+      "subject": "petit",
+      "object": "four",
+      "dependentPossessive": "four",
+      "independentPossessive": "fours",
+      "reflexive": "petitself"
+    },
+    {
+      "subject": "peyo",
+      "object": "te",
+      "dependentPossessive": "tes",
+      "independentPossessive": "tes",
+      "reflexive": "peyoself"
+    },
+    {
+      "subject": "ph",
+      "object": "php",
+      "dependentPossessive": "phs",
+      "independentPossessive": "phs",
+      "reflexive": "phpself"
+    },
+    {
+      "subject": "phan",
+      "object": "tom",
+      "dependentPossessive": "toms",
+      "independentPossessive": "toms",
+      "reflexive": "phantomself"
+    },
+    {
+      "subject": "phey",
+      "object": "phem",
+      "dependentPossessive": "pheir",
+      "independentPossessive": "pheirs",
+      "reflexive": "pheirself"
+    },
+    {
+      "subject": "pi",
+      "object": "pic",
+      "dependentPossessive": "pict",
+      "independentPossessive": "pictor",
+      "reflexive": "pictorself"
+    },
+    {
+      "subject": "pi",
+      "object": "pil",
+      "dependentPossessive": "pilo",
+      "independentPossessive": "pilot",
+      "reflexive": "pilotself"
+    },
+    {
+      "subject": "pi",
+      "object": "pin",
+      "dependentPossessive": "ion",
+      "independentPossessive": "ñon",
+      "reflexive": "piñonself"
+    },
+    {
+      "subject": "pi",
+      "object": "pin",
+      "dependentPossessive": "pine",
+      "independentPossessive": "pines",
+      "reflexive": "pineself"
+    },
+    {
+      "subject": "pi",
+      "object": "pir",
+      "dependentPossessive": "pira",
+      "independentPossessive": "pirat",
+      "reflexive": "pirateself"
+    },
+    {
+      "subject": "pi",
+      "object": "pir",
+      "dependentPossessive": "pis",
+      "independentPossessive": "pis",
+      "reflexive": "piself"
+    },
+    {
+      "subject": "pic",
+      "object": "pim",
+      "dependentPossessive": "per",
+      "independentPossessive": "pers",
+      "reflexive": "pimself"
+    },
+    {
+      "subject": "pike",
+      "object": "let",
+      "dependentPossessive": "pikes",
+      "independentPossessive": "pikes",
+      "reflexive": "pikeletself"
+    },
+    {
+      "subject": "pine",
+      "object": "apple",
+      "dependentPossessive": "pines",
+      "independentPossessive": "apples",
+      "reflexive": "pineself"
+    },
+    {
+      "subject": "pit",
+      "object": "pitch",
+      "dependentPossessive": "pits",
+      "independentPossessive": "pitc",
+      "reflexive": "pitchself"
+    },
+    {
+      "subject": "pix",
+      "object": "pix",
+      "dependentPossessive": "pixs",
+      "independentPossessive": "pixs",
+      "reflexive": "pixself"
+    },
+    {
+      "subject": "pla",
+      "object": "plasma",
+      "dependentPossessive": "pas",
+      "independentPossessive": "plas",
+      "reflexive": "plasmaself"
+    },
+    {
+      "subject": "pla",
+      "object": "plat",
+      "dependentPossessive": "tin",
+      "independentPossessive": "tinum",
+      "reflexive": "platinumself"
+    },
+    {
+      "subject": "pla",
+      "object": "play",
+      "dependentPossessive": "plays",
+      "independentPossessive": "plays",
+      "reflexive": "playself"
+    },
+    {
+      "subject": "plan",
+      "object": "tain",
+      "dependentPossessive": "plans",
+      "independentPossessive": "tains",
+      "reflexive": "planself"
+    },
+    {
+      "subject": "plum",
+      "object": "plum",
+      "dependentPossessive": "plums",
+      "independentPossessive": "plums",
+      "reflexive": "plumself"
+    },
+    {
+      "subject": "po",
+      "object": "ope",
+      "dependentPossessive": "op",
+      "independentPossessive": "hop",
+      "reflexive": "hopeself"
+    },
+    {
+      "subject": "po",
+      "object": "pol",
+      "dependentPossessive": "polaire",
+      "independentPossessive": "polaris",
+      "reflexive": "polariself"
+    },
+    {
+      "subject": "po",
+      "object": "poll",
+      "dependentPossessive": "lux",
+      "independentPossessive": "lux",
+      "reflexive": "polluxself"
+    },
+    {
+      "subject": "po",
+      "object": "pon",
+      "dependentPossessive": "der",
+      "independentPossessive": "deros",
+      "reflexive": "ponderosaself"
+    },
+    {
+      "subject": "po",
+      "object": "pon",
+      "dependentPossessive": "od",
+      "independentPossessive": "ond",
+      "reflexive": "pondself"
+    },
+    {
+      "subject": "po",
+      "object": "pon",
+      "dependentPossessive": "ond",
+      "independentPossessive": "onder",
+      "reflexive": "ponderself"
+    },
+    {
+      "subject": "po",
+      "object": "pon",
+      "dependentPossessive": "pos",
+      "independentPossessive": "pons",
+      "reflexive": "ponself"
     },
     {
       "subject": "po",
@@ -198,11 +6449,1068 @@
       "reflexive": "poself"
     },
     {
+      "subject": "po",
+      "object": "pop",
+      "dependentPossessive": "lar",
+      "independentPossessive": "lars",
+      "reflexive": "poplarself"
+    },
+    {
+      "subject": "po",
+      "object": "pop",
+      "dependentPossessive": "py",
+      "independentPossessive": "oppy",
+      "reflexive": "poppyself"
+    },
+    {
+      "subject": "po",
+      "object": "por",
+      "dependentPossessive": "port",
+      "independentPossessive": "port",
+      "reflexive": "portself"
+    },
+    {
+      "subject": "po",
+      "object": "posit",
+      "dependentPossessive": "pos",
+      "independentPossessive": "posi",
+      "reflexive": "positiveself"
+    },
+    {
+      "subject": "polvo",
+      "object": "ron",
+      "dependentPossessive": "rons",
+      "independentPossessive": "rons",
+      "reflexive": "polvoronself"
+    },
+    {
+      "subject": "pom",
+      "object": "pom",
+      "dependentPossessive": "poms",
+      "independentPossessive": "poms",
+      "reflexive": "pomself"
+    },
+    {
+      "subject": "pom",
+      "object": "pome",
+      "dependentPossessive": "pomes",
+      "independentPossessive": "pomes",
+      "reflexive": "pomself"
+    },
+    {
+      "subject": "pop",
+      "object": "sicle",
+      "dependentPossessive": "pops",
+      "independentPossessive": "pops",
+      "reflexive": "popself"
+    },
+    {
+      "subject": "pp",
+      "object": "ppt",
+      "dependentPossessive": "pps",
+      "independentPossessive": "pps",
+      "reflexive": "ppself"
+    },
+    {
+      "subject": "pra",
+      "object": "line",
+      "dependentPossessive": "pras",
+      "independentPossessive": "pras",
+      "reflexive": "pralineself"
+    },
+    {
+      "subject": "pra",
+      "object": "pra",
+      "dependentPossessive": "praseo",
+      "independentPossessive": "pras",
+      "reflexive": "praseoself"
+    },
+    {
+      "subject": "prai",
+      "object": "prar",
+      "dependentPossessive": "rie",
+      "independentPossessive": "airie",
+      "reflexive": "prairieself"
+    },
+    {
+      "subject": "pre",
+      "object": "per",
+      "dependentPossessive": "pres",
+      "independentPossessive": "presen",
+      "reflexive": "presentself"
+    },
+    {
+      "subject": "pri",
+      "object": "par",
+      "dependentPossessive": "prid",
+      "independentPossessive": "prida",
+      "reflexive": "prideself"
+    },
+    {
+      "subject": "pri",
+      "object": "pir",
+      "dependentPossessive": "pis",
+      "independentPossessive": "pris",
+      "reflexive": "prismself"
+    },
+    {
+      "subject": "pri",
+      "object": "print",
+      "dependentPossessive": "pris",
+      "independentPossessive": "prints",
+      "reflexive": "printself"
+    },
+    {
+      "subject": "pri",
+      "object": "private",
+      "dependentPossessive": "pris",
+      "independentPossessive": "privs",
+      "reflexive": "privateself"
+    },
+    {
+      "subject": "prickly",
+      "object": "pear",
+      "dependentPossessive": "pear",
+      "independentPossessive": "pears",
+      "reflexive": "pricklyself"
+    },
+    {
+      "subject": "pro",
+      "object": "por",
+      "dependentPossessive": "prol",
+      "independentPossessive": "prolo",
+      "reflexive": "prologueself"
+    },
+    {
+      "subject": "pro",
+      "object": "proc",
+      "dependentPossessive": "yon",
+      "independentPossessive": "cyon",
+      "reflexive": "procyonself"
+    },
+    {
+      "subject": "pro",
+      "object": "prosp",
+      "dependentPossessive": "pros",
+      "independentPossessive": "prospi",
+      "reflexive": "prospitself"
+    },
+    {
+      "subject": "profi",
+      "object": "terole",
+      "dependentPossessive": "fiter",
+      "independentPossessive": "fiters",
+      "reflexive": "profiself"
+    },
+    {
+      "subject": "profi",
+      "object": "terole",
+      "dependentPossessive": "profis",
+      "independentPossessive": "profis",
+      "reflexive": "profiself"
+    },
+    {
+      "subject": "profi",
+      "object": "terole",
+      "dependentPossessive": "profiter",
+      "independentPossessive": "profiters",
+      "reflexive": "profiself"
+    },
+    {
+      "subject": "psi",
+      "object": "psim",
+      "dependentPossessive": "psis",
+      "independentPossessive": "psis",
+      "reflexive": "psiself"
+    },
+    {
+      "subject": "pta",
+      "object": "mig",
+      "dependentPossessive": "ptar",
+      "independentPossessive": "ptarm",
+      "reflexive": "ptarmiganself"
+    },
+    {
+      "subject": "pu",
+      "object": "public",
+      "dependentPossessive": "pubs",
+      "independentPossessive": "pubs",
+      "reflexive": "publicself"
+    },
+    {
+      "subject": "pu",
+      "object": "uer",
+      "dependentPossessive": "puer",
+      "independentPossessive": "puert",
+      "reflexive": "puertoself"
+    },
+    {
+      "subject": "puff",
+      "object": "puff",
+      "dependentPossessive": "puffs",
+      "independentPossessive": "puffs",
+      "reflexive": "puffself"
+    },
+    {
+      "subject": "puls",
+      "object": "puls",
+      "dependentPossessive": "pulsar",
+      "independentPossessive": "pulsars",
+      "reflexive": "pulself"
+    },
+    {
+      "subject": "pum",
+      "object": "pum",
+      "dependentPossessive": "pums",
+      "independentPossessive": "pums",
+      "reflexive": "pumself"
+    },
+    {
+      "subject": "pump",
+      "object": "pumpkin",
+      "dependentPossessive": "pumpkins",
+      "independentPossessive": "pumpkins",
+      "reflexive": "pumpkinself"
+    },
+    {
+      "subject": "py",
+      "object": "pyrit",
+      "dependentPossessive": "pyr",
+      "independentPossessive": "pyri",
+      "reflexive": "pyriteself"
+    },
+    {
+      "subject": "py",
+      "object": "python",
+      "dependentPossessive": "pys",
+      "independentPossessive": "pys",
+      "reflexive": "pyself"
+    },
+    {
+      "subject": "py",
+      "object": "pyx",
+      "dependentPossessive": "pyxis",
+      "independentPossessive": "pyxis",
+      "reflexive": "pyxiself"
+    },
+    {
+      "subject": "py",
+      "object": "thon",
+      "dependentPossessive": "thons",
+      "independentPossessive": "thons",
+      "reflexive": "thonself"
+    },
+    {
+      "subject": "q",
+      "object": "q",
+      "dependentPossessive": "q’s",
+      "independentPossessive": "q’s",
+      "reflexive": "qself"
+    },
+    {
+      "subject": "qe",
+      "object": "qer",
+      "dependentPossessive": "qers",
+      "independentPossessive": "qem",
+      "reflexive": "qemself"
+    },
+    {
+      "subject": "qu",
+      "object": "qu",
+      "dependentPossessive": "qus",
+      "independentPossessive": "qus",
+      "reflexive": "quself"
+    },
+    {
+      "subject": "qua",
+      "object": "il",
+      "dependentPossessive": "quai",
+      "independentPossessive": "quail",
+      "reflexive": "quailself"
+    },
+    {
+      "subject": "qua",
+      "object": "quad",
+      "dependentPossessive": "quar",
+      "independentPossessive": "quadruple",
+      "reflexive": "quadruself"
+    },
+    {
+      "subject": "qua",
+      "object": "quar",
+      "dependentPossessive": "quet",
+      "independentPossessive": "quartet",
+      "reflexive": "quarself"
+    },
+    {
+      "subject": "que",
+      "object": "queb",
+      "dependentPossessive": "eb",
+      "independentPossessive": "ebec",
+      "reflexive": "quebecself"
+    },
+    {
+      "subject": "que",
+      "object": "quen",
+      "dependentPossessive": "quen",
+      "independentPossessive": "queen",
+      "reflexive": "queenself"
+    },
+    {
+      "subject": "quet",
+      "object": "zal",
+      "dependentPossessive": "quets",
+      "independentPossessive": "quets",
+      "reflexive": "quetself"
+    },
+    {
+      "subject": "qui",
+      "object": "quin",
+      "dependentPossessive": "quint",
+      "independentPossessive": "quintuple",
+      "reflexive": "quintuself"
+    },
+    {
+      "subject": "quin",
+      "object": "quince",
+      "dependentPossessive": "quinces",
+      "independentPossessive": "quinces",
+      "reflexive": "quinceself"
+    },
+    {
+      "subject": "r",
+      "object": "r",
+      "dependentPossessive": "r’s",
+      "independentPossessive": "r’s",
+      "reflexive": "rself"
+    },
+    {
+      "subject": "ra",
+      "object": "ar",
+      "dependentPossessive": "al",
+      "independentPossessive": "ral",
+      "reflexive": "aralself"
+    },
+    {
+      "subject": "ra",
+      "object": "ar",
+      "dependentPossessive": "fur",
+      "independentPossessive": "fura",
+      "reflexive": "arafuraself"
+    },
+    {
+      "subject": "ra",
+      "object": "arch",
+      "dependentPossessive": "chai",
+      "independentPossessive": "chaic",
+      "reflexive": "archaicself"
+    },
+    {
+      "subject": "ra",
+      "object": "arct",
+      "dependentPossessive": "rus",
+      "independentPossessive": "turus",
+      "reflexive": "arcturuself"
+    },
+    {
+      "subject": "ra",
+      "object": "tic",
+      "dependentPossessive": "adri",
+      "independentPossessive": "adria",
+      "reflexive": "adriaticself"
+    },
+    {
+      "subject": "rai",
+      "object": "sin",
+      "dependentPossessive": "rais",
+      "independentPossessive": "sins",
+      "reflexive": "raiself"
+    },
+    {
+      "subject": "ram",
+      "object": "butan",
+      "dependentPossessive": "rams",
+      "independentPossessive": "buts",
+      "reflexive": "rambutanself"
+    },
+    {
+      "subject": "rasp",
+      "object": "berry",
+      "dependentPossessive": "berr",
+      "independentPossessive": "berrs",
+      "reflexive": "raspself"
+    },
+    {
+      "subject": "rasp",
+      "object": "rasp",
+      "dependentPossessive": "rasps",
+      "independentPossessive": "rasps",
+      "reflexive": "raspself"
+    },
+    {
+      "subject": "rau",
+      "object": "aur",
+      "dependentPossessive": "ror",
+      "independentPossessive": "rora",
+      "reflexive": "auroraself"
+    },
+    {
+      "subject": "re",
+      "object": "butia",
+      "dependentPossessive": "butis",
+      "independentPossessive": "butis",
+      "reflexive": "rebutiaself"
+    },
+    {
+      "subject": "re",
+      "object": "or",
+      "dependentPossessive": "reg",
+      "independentPossessive": "oreg",
+      "reflexive": "oreganoself"
+    },
+    {
+      "subject": "re",
+      "object": "or",
+      "dependentPossessive": "reg",
+      "independentPossessive": "oreg",
+      "reflexive": "oregonself"
+    },
+    {
+      "subject": "re",
+      "object": "prise",
+      "dependentPossessive": "prise",
+      "independentPossessive": "prises",
+      "reflexive": "repriseself"
+    },
+    {
+      "subject": "re",
+      "object": "quiem",
+      "dependentPossessive": "ems",
+      "independentPossessive": "ems",
+      "reflexive": "requiemself"
+    },
+    {
+      "subject": "re",
+      "object": "reg",
+      "dependentPossessive": "gor",
+      "independentPossessive": "egor",
+      "reflexive": "regorself"
+    },
+    {
+      "subject": "re",
+      "object": "reg",
+      "dependentPossessive": "gul",
+      "independentPossessive": "gulus",
+      "reflexive": "reguluself"
+    },
+    {
+      "subject": "re",
+      "object": "ren",
+      "dependentPossessive": "reis",
+      "independentPossessive": "reisi",
+      "reflexive": "reniself"
+    },
+    {
+      "subject": "re",
+      "object": "ren",
+      "dependentPossessive": "renai",
+      "independentPossessive": "renais",
+      "reflexive": "renaissanself"
+    },
+    {
+      "subject": "re",
+      "object": "rev",
+      "dependentPossessive": "revo",
+      "independentPossessive": "revol",
+      "reflexive": "revolutionself"
+    },
+    {
+      "subject": "rea",
+      "object": "er",
+      "dependentPossessive": "ath",
+      "independentPossessive": "arth",
+      "reflexive": "earthself"
+    },
+    {
+      "subject": "rebu",
+      "object": "tia",
+      "dependentPossessive": "rebus",
+      "independentPossessive": "ties",
+      "reflexive": "rebutiaself"
+    },
+    {
+      "subject": "red",
+      "object": "bean",
+      "dependentPossessive": "reds",
+      "independentPossessive": "reds",
+      "reflexive": "redbeanself"
+    },
+    {
+      "subject": "red",
+      "object": "red",
+      "dependentPossessive": "reds",
+      "independentPossessive": "reds",
+      "reflexive": "redself"
+    },
+    {
+      "subject": "red",
+      "object": "velvet",
+      "dependentPossessive": "reds",
+      "independentPossessive": "reds",
+      "reflexive": "redself"
+    },
+    {
+      "subject": "ree",
+      "object": "reef",
+      "dependentPossessive": "ref",
+      "independentPossessive": "refs",
+      "reflexive": "reefself"
+    },
+    {
+      "subject": "reed",
+      "object": "reed",
+      "dependentPossessive": "reeds",
+      "independentPossessive": "reeds",
+      "reflexive": "reedself"
+    },
+    {
+      "subject": "reh",
+      "object": "re",
+      "dependentPossessive": "rez",
+      "independentPossessive": "rez",
+      "reflexive": "redself"
+    },
+    {
+      "subject": "reve",
+      "object": "nant",
+      "dependentPossessive": "reves",
+      "independentPossessive": "reves",
+      "reflexive": "reveself"
+    },
+    {
+      "subject": "rho",
+      "object": "rhod",
+      "dependentPossessive": "rhode",
+      "independentPossessive": "rhodes",
+      "reflexive": "rhodeself"
+    },
+    {
+      "subject": "rho",
+      "object": "rhode",
+      "dependentPossessive": "od",
+      "independentPossessive": "ode",
+      "reflexive": "rhodeself"
+    },
+    {
+      "subject": "rho",
+      "object": "rhon",
+      "dependentPossessive": "rhos",
+      "independentPossessive": "rhos",
+      "reflexive": "rhoself"
+    },
+    {
+      "subject": "rhy",
+      "object": "rhythm",
+      "dependentPossessive": "rhyth",
+      "independentPossessive": "rhyth",
+      "reflexive": "rhythmself"
+    },
+    {
+      "subject": "ri",
+      "object": "ar",
+      "dependentPossessive": "ariz",
+      "independentPossessive": "arizo",
+      "reflexive": "arizonaself"
+    },
+    {
+      "subject": "ri",
+      "object": "rib",
+      "dependentPossessive": "ribo",
+      "independentPossessive": "ribbon",
+      "reflexive": "ribbonself"
+    },
+    {
+      "subject": "ri",
+      "object": "ric",
+      "dependentPossessive": "co",
+      "independentPossessive": "ico",
+      "reflexive": "ricoself"
+    },
+    {
+      "subject": "ri",
+      "object": "ril",
+      "dependentPossessive": "gel",
+      "independentPossessive": "gels",
+      "reflexive": "rigelself"
+    },
+    {
+      "subject": "ri",
+      "object": "riv",
+      "dependentPossessive": "rier",
+      "independentPossessive": "river",
+      "reflexive": "riverself"
+    },
+    {
+      "subject": "rie",
+      "object": "eer",
+      "dependentPossessive": "eri",
+      "independentPossessive": "erie",
+      "reflexive": "eeriself"
+    },
+    {
+      "subject": "rie",
+      "object": "orch",
+      "dependentPossessive": "id",
+      "independentPossessive": "chid",
+      "reflexive": "orchidself"
+    },
+    {
+      "subject": "rie",
+      "object": "rhem",
+      "dependentPossessive": "rer",
+      "independentPossessive": "rers",
+      "reflexive": "rerself"
+    },
+    {
+      "subject": "rigau",
+      "object": "don",
+      "dependentPossessive": "dons",
+      "independentPossessive": "dons",
+      "reflexive": "donself"
+    },
+    {
+      "subject": "rii",
+      "object": "ser",
+      "dependentPossessive": "riis",
+      "independentPossessive": "riiser",
+      "reflexive": "riiserself"
+    },
+    {
+      "subject": "ro",
+      "object": "ar",
+      "dependentPossessive": "os",
+      "independentPossessive": "ross",
+      "reflexive": "rosself"
+    },
+    {
+      "subject": "ro",
+      "object": "coco",
+      "dependentPossessive": "rocs",
+      "independentPossessive": "rocs",
+      "reflexive": "rocself"
+    },
+    {
+      "subject": "ro",
+      "object": "or",
+      "dependentPossessive": "ca",
+      "independentPossessive": "oca",
+      "reflexive": "orcaself"
+    },
+    {
+      "subject": "ro",
+      "object": "ren",
+      "dependentPossessive": "ob",
+      "independentPossessive": "obin",
+      "reflexive": "robinself"
+    },
+    {
+      "subject": "ro",
+      "object": "rol",
+      "dependentPossessive": "ler",
+      "independentPossessive": "lers",
+      "reflexive": "rollerself"
+    },
+    {
+      "subject": "ro",
+      "object": "ros",
+      "dependentPossessive": "rose",
+      "independentPossessive": "roses",
+      "reflexive": "roseself"
+    },
+    {
+      "subject": "ro",
+      "object": "sette",
+      "dependentPossessive": "rose",
+      "independentPossessive": "rose",
+      "reflexive": "rosetteself"
+    },
+    {
+      "subject": "ron",
+      "object": "do",
+      "dependentPossessive": "rons",
+      "independentPossessive": "rons",
+      "reflexive": "rondoself"
+    },
+    {
+      "subject": "rosu",
+      "object": "laria",
+      "dependentPossessive": "lar",
+      "independentPossessive": "larias",
+      "reflexive": "rosuself"
+    },
+    {
+      "subject": "rou",
+      "object": "round",
+      "dependentPossessive": "rous",
+      "independentPossessive": "rous",
+      "reflexive": "roundself"
+    },
+    {
+      "subject": "ru",
+      "object": "gul",
+      "dependentPossessive": "aru",
+      "independentPossessive": "aru",
+      "reflexive": "aruguself"
+    },
+    {
+      "subject": "ru",
+      "object": "roos",
+      "dependentPossessive": "ter",
+      "independentPossessive": "ster",
+      "reflexive": "roosterself"
+    },
+    {
+      "subject": "ru",
+      "object": "rube",
+      "dependentPossessive": "rubes",
+      "independentPossessive": "rubes",
+      "reflexive": "rubeself"
+    },
+    {
+      "subject": "ru",
+      "object": "urb",
+      "dependentPossessive": "urba",
+      "independentPossessive": "urban",
+      "reflexive": "urbanself"
+    },
+    {
+      "subject": "ru",
+      "object": "ut",
+      "dependentPossessive": "ust",
+      "independentPossessive": "rust",
+      "reflexive": "rustself"
+    },
+    {
+      "subject": "s",
+      "object": "s",
+      "dependentPossessive": "s’s",
+      "independentPossessive": "s’s",
+      "reflexive": "esself"
+    },
+    {
+      "subject": "sa",
+      "object": "kat",
+      "dependentPossessive": "sas",
+      "independentPossessive": "saska",
+      "reflexive": "saskatchewanself"
+    },
+    {
+      "subject": "sa",
+      "object": "sage",
+      "dependentPossessive": "sas",
+      "independentPossessive": "saes",
+      "reflexive": "sageself"
+    },
+    {
+      "subject": "sa",
+      "object": "sai",
+      "dependentPossessive": "sas",
+      "independentPossessive": "sais",
+      "reflexive": "saiself"
+    },
+    {
+      "subject": "sa",
+      "object": "sal",
+      "dependentPossessive": "li",
+      "independentPossessive": "lish",
+      "reflexive": "salishself"
+    },
+    {
+      "subject": "sa",
+      "object": "sal",
+      "dependentPossessive": "to",
+      "independentPossessive": "ton",
+      "reflexive": "saltonself"
+    },
+    {
+      "subject": "sa",
+      "object": "sam",
+      "dependentPossessive": "mo",
+      "independentPossessive": "moa",
+      "reflexive": "samoaself"
+    },
+    {
+      "subject": "sa",
+      "object": "sap",
+      "dependentPossessive": "saps",
+      "independentPossessive": "saps",
+      "reflexive": "sapself"
+    },
+    {
+      "subject": "sa",
+      "object": "sar",
+      "dependentPossessive": "arga",
+      "independentPossessive": "sarga",
+      "reflexive": "sargassoself"
+    },
+    {
+      "subject": "sa",
+      "object": "sar",
+      "dependentPossessive": "dir",
+      "independentPossessive": "dira",
+      "reflexive": "sadiraself"
+    },
+    {
+      "subject": "sa",
+      "object": "sat",
+      "dependentPossessive": "sat",
+      "independentPossessive": "sati",
+      "reflexive": "satinself"
+    },
+    {
+      "subject": "sa",
+      "object": "sat",
+      "dependentPossessive": "satur",
+      "independentPossessive": "satu",
+      "reflexive": "saturdayself"
+    },
+    {
+      "subject": "sa",
+      "object": "sav",
+      "dependentPossessive": "av",
+      "independentPossessive": "avu",
+      "reflexive": "savuself"
+    },
+    {
+      "subject": "sa",
+      "object": "tyr",
+      "dependentPossessive": "tyr",
+      "independentPossessive": "tyrs",
+      "reflexive": "tyrself"
+    },
+    {
+      "subject": "sa",
+      "object": "tyress",
+      "dependentPossessive": "tyr",
+      "independentPossessive": "tyrs",
+      "reflexive": "satyresself"
+    },
+    {
+      "subject": "sae",
+      "object": "saer",
+      "dependentPossessive": "saer",
+      "independentPossessive": "saers",
+      "reflexive": "saerself"
+    },
+    {
+      "subject": "sans",
+      "object": "rival",
+      "dependentPossessive": "sans",
+      "independentPossessive": "sans",
+      "reflexive": "sansself"
+    },
+    {
+      "subject": "sans",
+      "object": "sans",
+      "dependentPossessive": "sans",
+      "independentPossessive": "sans",
+      "reflexive": "sanself"
+    },
+    {
+      "subject": "sca",
+      "object": "sar",
+      "dependentPossessive": "scarle",
+      "independentPossessive": "scarlet",
+      "reflexive": "scarletself"
+    },
+    {
+      "subject": "sco",
+      "object": "ot",
+      "dependentPossessive": "oti",
+      "independentPossessive": "otia",
+      "reflexive": "scotiaself"
+    },
+    {
+      "subject": "sco",
+      "object": "scorch",
+      "dependentPossessive": "scor",
+      "independentPossessive": "scors",
+      "reflexive": "scorchself"
+    },
+    {
+      "subject": "scri",
+      "object": "script",
+      "dependentPossessive": "scris",
+      "independentPossessive": "scripts",
+      "reflexive": "scriptself"
+    },
+    {
+      "subject": "scu",
+      "object": "scoot",
+      "dependentPossessive": "ter",
+      "independentPossessive": "ters",
+      "reflexive": "scooterself"
+    },
+    {
+      "subject": "scu",
+      "object": "scub",
+      "dependentPossessive": "ba",
+      "independentPossessive": "uba",
+      "reflexive": "scubaself"
+    },
+    {
+      "subject": "scy",
+      "object": "scyll",
+      "dependentPossessive": "scyr",
+      "independentPossessive": "scyrs",
+      "reflexive": "scyself"
+    },
+    {
+      "subject": "scy",
+      "object": "scyll",
+      "dependentPossessive": "scys",
+      "independentPossessive": "scys",
+      "reflexive": "scyself"
+    },
+    {
+      "subject": "se",
+      "object": "dum",
+      "dependentPossessive": "ses",
+      "independentPossessive": "ses",
+      "reflexive": "sedumself"
+    },
+    {
+      "subject": "se",
+      "object": "hem",
+      "dependentPossessive": "hes",
+      "independentPossessive": "hes",
+      "reflexive": "hemself"
+    },
+    {
+      "subject": "se",
+      "object": "hir",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hirself"
+    },
+    {
+      "subject": "se",
+      "object": "sem",
+      "dependentPossessive": "seii",
+      "independentPossessive": "semi",
+      "reflexive": "semiself"
+    },
+    {
+      "subject": "se",
+      "object": "sem",
+      "dependentPossessive": "ser",
+      "independentPossessive": "sers",
+      "reflexive": "serself"
+    },
+    {
+      "subject": "se",
+      "object": "seque",
+      "dependentPossessive": "quoi",
+      "independentPossessive": "quoia",
+      "reflexive": "sequoiaself"
+    },
+    {
+      "subject": "se",
+      "object": "ser",
+      "dependentPossessive": "seren",
+      "independentPossessive": "serenit",
+      "reflexive": "serenityself"
+    },
+    {
+      "subject": "se",
+      "object": "set",
+      "dependentPossessive": "to",
+      "independentPossessive": "eto",
+      "reflexive": "setoself"
+    },
+    {
+      "subject": "se",
+      "object": "sextet",
+      "dependentPossessive": "tes",
+      "independentPossessive": "tes",
+      "reflexive": "sextetself"
+    },
+    {
       "subject": "se",
       "object": "sim",
       "dependentPossessive": "ser",
       "independentPossessive": "sers",
       "reflexive": "serself"
+    },
+    {
+      "subject": "se",
+      "object": "sim",
+      "dependentPossessive": "ser",
+      "independentPossessive": "sers",
+      "reflexive": "simself"
+    },
+    {
+      "subject": "se",
+      "object": "syr",
+      "dependentPossessive": "sym",
+      "independentPossessive": "syrs",
+      "reflexive": "syrself"
+    },
+    {
+      "subject": "semi",
+      "object": "freddo",
+      "dependentPossessive": "semis",
+      "independentPossessive": "semis",
+      "reflexive": "semiself"
+    },
+    {
+      "subject": "sep",
+      "object": "tet",
+      "dependentPossessive": "seps",
+      "independentPossessive": "seps",
+      "reflexive": "septetself"
+    },
+    {
+      "subject": "sere",
+      "object": "nade",
+      "dependentPossessive": "ser",
+      "independentPossessive": "sers",
+      "reflexive": "sereself"
+    },
+    {
+      "subject": "set",
+      "object": "set",
+      "dependentPossessive": "sets",
+      "independentPossessive": "sets",
+      "reflexive": "setself"
+    },
+    {
+      "subject": "sev",
+      "object": "seven",
+      "dependentPossessive": "sevs",
+      "independentPossessive": "sevs",
+      "reflexive": "sevenself"
+    },
+    {
+      "subject": "sha",
+      "object": "shad",
+      "dependentPossessive": "ad",
+      "independentPossessive": "ade",
+      "reflexive": "shadeself"
+    },
+    {
+      "subject": "sha",
+      "object": "shad",
+      "dependentPossessive": "ado",
+      "independentPossessive": "adow",
+      "reflexive": "shadowself"
+    },
+    {
+      "subject": "shau",
+      "object": "shul",
+      "dependentPossessive": "aul",
+      "independentPossessive": "aula",
+      "reflexive": "shaulaself"
     },
     {
       "subject": "she",
@@ -212,11 +7520,116 @@
       "reflexive": "herself"
     },
     {
+      "subject": "she",
+      "object": "sheer",
+      "dependentPossessive": "sheers",
+      "independentPossessive": "sheers",
+      "reflexive": "sheerself"
+    },
+    {
+      "subject": "sher",
+      "object": "bet",
+      "dependentPossessive": "sher",
+      "independentPossessive": "shers",
+      "reflexive": "sherself"
+    },
+    {
+      "subject": "shey",
+      "object": "shem",
+      "dependentPossessive": "sheir",
+      "independentPossessive": "sheirs",
+      "reflexive": "shemself"
+    },
+    {
+      "subject": "shi",
+      "object": "shiel",
+      "dependentPossessive": "shield",
+      "independentPossessive": "shields",
+      "reflexive": "shieldself"
+    },
+    {
+      "subject": "sho",
+      "object": "short",
+      "dependentPossessive": "shor",
+      "independentPossessive": "shors",
+      "reflexive": "shortself"
+    },
+    {
+      "subject": "short",
+      "object": "cake",
+      "dependentPossessive": "shor",
+      "independentPossessive": "shors",
+      "reflexive": "shortcakeself"
+    },
+    {
+      "subject": "shrub",
+      "object": "shrub",
+      "dependentPossessive": "shrubs",
+      "independentPossessive": "shrubs",
+      "reflexive": "shrubself"
+    },
+    {
+      "subject": "shy",
+      "object": "hyr",
+      "dependentPossessive": "hyr",
+      "independentPossessive": "hyrs",
+      "reflexive": "hyrself"
+    },
+    {
+      "subject": "shy",
+      "object": "shy",
+      "dependentPossessive": "shys",
+      "independentPossessive": "shys",
+      "reflexive": "shyself"
+    },
+    {
       "subject": "si",
       "object": "hyr",
       "dependentPossessive": "hyr",
       "independentPossessive": "hyrs",
       "reflexive": "hyrself"
+    },
+    {
+      "subject": "si",
+      "object": "sib",
+      "dependentPossessive": "bu",
+      "independentPossessive": "buya",
+      "reflexive": "sibuyanself"
+    },
+    {
+      "subject": "si",
+      "object": "sig",
+      "dependentPossessive": "sima",
+      "independentPossessive": "sigma",
+      "reflexive": "sigmaself"
+    },
+    {
+      "subject": "si",
+      "object": "sil",
+      "dependentPossessive": "sil",
+      "independentPossessive": "silks",
+      "reflexive": "silkself"
+    },
+    {
+      "subject": "si",
+      "object": "sin",
+      "dependentPossessive": "sil",
+      "independentPossessive": "single",
+      "reflexive": "singleself"
+    },
+    {
+      "subject": "si",
+      "object": "six",
+      "dependentPossessive": "sixes",
+      "independentPossessive": "sixes",
+      "reflexive": "sixself"
+    },
+    {
+      "subject": "sie",
+      "object": "hir",
+      "dependentPossessive": "hen",
+      "independentPossessive": "hirs",
+      "reflexive": "henself"
     },
     {
       "subject": "sie",
@@ -226,6 +7639,300 @@
       "reflexive": "hirself"
     },
     {
+      "subject": "silv",
+      "object": "vana",
+      "dependentPossessive": "silvs",
+      "independentPossessive": "silvs",
+      "reflexive": "silvself"
+    },
+    {
+      "subject": "sing",
+      "object": "sing",
+      "dependentPossessive": "sings",
+      "independentPossessive": "sings",
+      "reflexive": "singself"
+    },
+    {
+      "subject": "ska",
+      "object": "skat",
+      "dependentPossessive": "kae",
+      "independentPossessive": "kate",
+      "reflexive": "skateself"
+    },
+    {
+      "subject": "ske",
+      "object": "sek",
+      "dependentPossessive": "skin",
+      "independentPossessive": "skins",
+      "reflexive": "skinself"
+    },
+    {
+      "subject": "ski",
+      "object": "kip",
+      "dependentPossessive": "ip",
+      "independentPossessive": "skip",
+      "reflexive": "skipself"
+    },
+    {
+      "subject": "ski",
+      "object": "sek",
+      "dependentPossessive": "sif",
+      "independentPossessive": "skiff",
+      "reflexive": "skiffself"
+    },
+    {
+      "subject": "slud",
+      "object": "sludge",
+      "dependentPossessive": "sludges",
+      "independentPossessive": "sludges",
+      "reflexive": "sludgeself"
+    },
+    {
+      "subject": "sm",
+      "object": "sml",
+      "dependentPossessive": "smls",
+      "independentPossessive": "smls",
+      "reflexive": "smlself"
+    },
+    {
+      "subject": "smo",
+      "object": "smores",
+      "dependentPossessive": "smore",
+      "independentPossessive": "smores",
+      "reflexive": "smoreself"
+    },
+    {
+      "subject": "smoke",
+      "object": "smoke",
+      "dependentPossessive": "smokes",
+      "independentPossessive": "smokes",
+      "reflexive": "smokeself"
+    },
+    {
+      "subject": "snow",
+      "object": "cone",
+      "dependentPossessive": "cones",
+      "independentPossessive": "cones",
+      "reflexive": "snowconeself"
+    },
+    {
+      "subject": "so",
+      "object": "nata",
+      "dependentPossessive": "nas",
+      "independentPossessive": "nas",
+      "reflexive": "sonaself"
+    },
+    {
+      "subject": "so",
+      "object": "sol",
+      "dependentPossessive": "soli",
+      "independentPossessive": "solit",
+      "reflexive": "soliself"
+    },
+    {
+      "subject": "so",
+      "object": "sol",
+      "dependentPossessive": "solo",
+      "independentPossessive": "solo",
+      "reflexive": "soloself"
+    },
+    {
+      "subject": "so",
+      "object": "sol",
+      "dependentPossessive": "sols",
+      "independentPossessive": "sols",
+      "reflexive": "solaireself"
+    },
+    {
+      "subject": "so",
+      "object": "som",
+      "dependentPossessive": "mo",
+      "independentPossessive": "mov",
+      "reflexive": "somovself"
+    },
+    {
+      "subject": "so",
+      "object": "sop",
+      "dependentPossessive": "sopra",
+      "independentPossessive": "sopran",
+      "reflexive": "sopranoself"
+    },
+    {
+      "subject": "so",
+      "object": "soph",
+      "dependentPossessive": "ros",
+      "independentPossessive": "rosyne",
+      "reflexive": "sophrosyneself"
+    },
+    {
+      "subject": "so",
+      "object": "sor",
+      "dependentPossessive": "sars",
+      "independentPossessive": "soars",
+      "reflexive": "soarself"
+    },
+    {
+      "subject": "so",
+      "object": "south",
+      "dependentPossessive": "oth",
+      "independentPossessive": "outh",
+      "reflexive": "southself"
+    },
+    {
+      "subject": "sona",
+      "object": "tina",
+      "dependentPossessive": "sonas",
+      "independentPossessive": "sonas",
+      "reflexive": "sonaself"
+    },
+    {
+      "subject": "sor",
+      "object": "bet",
+      "dependentPossessive": "sor",
+      "independentPossessive": "bets",
+      "reflexive": "sorbetself"
+    },
+    {
+      "subject": "sor",
+      "object": "betes",
+      "dependentPossessive": "sor",
+      "independentPossessive": "betes",
+      "reflexive": "sorbetesself"
+    },
+    {
+      "subject": "sou",
+      "object": "source",
+      "dependentPossessive": "sour",
+      "independentPossessive": "sources",
+      "reflexive": "sourceself"
+    },
+    {
+      "subject": "sour",
+      "object": "sop",
+      "dependentPossessive": "sours",
+      "independentPossessive": "sops",
+      "reflexive": "sourself"
+    },
+    {
+      "subject": "spa",
+      "object": "ap",
+      "dependentPossessive": "sen",
+      "independentPossessive": "spen",
+      "reflexive": "aspenself"
+    },
+    {
+      "subject": "spe",
+      "object": "sep",
+      "dependentPossessive": "sel",
+      "independentPossessive": "spell",
+      "reflexive": "spellself"
+    },
+    {
+      "subject": "sphe",
+      "object": "sphene",
+      "dependentPossessive": "ene",
+      "independentPossessive": "phene",
+      "reflexive": "spheneself"
+    },
+    {
+      "subject": "sphe",
+      "object": "spher",
+      "dependentPossessive": "sphere",
+      "independentPossessive": "spheres",
+      "reflexive": "sphereself"
+    },
+    {
+      "subject": "sphi",
+      "object": "sphin",
+      "dependentPossessive": "sphinx",
+      "independentPossessive": "sphinx",
+      "reflexive": "sphinxself"
+    },
+    {
+      "subject": "spi",
+      "object": "insp",
+      "dependentPossessive": "spira",
+      "independentPossessive": "spirat",
+      "reflexive": "inspirationself"
+    },
+    {
+      "subject": "spi",
+      "object": "sep",
+      "dependentPossessive": "spine",
+      "independentPossessive": "spinal",
+      "reflexive": "spineself"
+    },
+    {
+      "subject": "spi",
+      "object": "spic",
+      "dependentPossessive": "ca",
+      "independentPossessive": "pica",
+      "reflexive": "spicaself"
+    },
+    {
+      "subject": "spir",
+      "object": "sprin",
+      "dependentPossessive": "spri",
+      "independentPossessive": "sprir",
+      "reflexive": "springself"
+    },
+    {
+      "subject": "splash",
+      "object": "splish",
+      "dependentPossessive": "splosh",
+      "independentPossessive": "splish",
+      "reflexive": "splishself"
+    },
+    {
+      "subject": "spoo",
+      "object": "spook",
+      "dependentPossessive": "spooks",
+      "independentPossessive": "spooks",
+      "reflexive": "spookself"
+    },
+    {
+      "subject": "spri",
+      "object": "sprinkles",
+      "dependentPossessive": "spris",
+      "independentPossessive": "spris",
+      "reflexive": "sprinklesself"
+    },
+    {
+      "subject": "spri",
+      "object": "sprite",
+      "dependentPossessive": "sprites",
+      "independentPossessive": "sprites",
+      "reflexive": "spriteself"
+    },
+    {
+      "subject": "spru",
+      "object": "sep",
+      "dependentPossessive": "ruce",
+      "independentPossessive": "spruce",
+      "reflexive": "spruceself"
+    },
+    {
+      "subject": "spu",
+      "object": "moni",
+      "dependentPossessive": "monis",
+      "independentPossessive": "monis",
+      "reflexive": "spumoniself"
+    },
+    {
+      "subject": "sq",
+      "object": "sql",
+      "dependentPossessive": "sqls",
+      "independentPossessive": "sqls",
+      "reflexive": "sqlself"
+    },
+    {
+      "subject": "src",
+      "object": "src",
+      "dependentPossessive": "srcs",
+      "independentPossessive": "srcs",
+      "reflexive": "srcself"
+    },
+    {
       "subject": "sta",
       "object": "stal",
       "dependentPossessive": "stal",
@@ -233,11 +7940,487 @@
       "reflexive": "stalself"
     },
     {
+      "subject": "sta",
+      "object": "star",
+      "dependentPossessive": "starb",
+      "independentPossessive": "starboar",
+      "reflexive": "starboardself"
+    },
+    {
+      "subject": "sta",
+      "object": "static",
+      "dependentPossessive": "stas",
+      "independentPossessive": "statics",
+      "reflexive": "staticself"
+    },
+    {
+      "subject": "star",
+      "object": "fruit",
+      "dependentPossessive": "fruits",
+      "independentPossessive": "fruits",
+      "reflexive": "starfruitself"
+    },
+    {
+      "subject": "stawb",
+      "object": "strawb",
+      "dependentPossessive": "strawbs",
+      "independentPossessive": "strawbs",
+      "reflexive": "strawbself"
+    },
+    {
+      "subject": "ste",
+      "object": "steel",
+      "dependentPossessive": "el",
+      "independentPossessive": "tel",
+      "reflexive": "steelself"
+    },
+    {
       "subject": "ste",
       "object": "step",
       "dependentPossessive": "step",
       "independentPossessive": "steps",
       "reflexive": "stepself"
+    },
+    {
+      "subject": "stel",
+      "object": "stel",
+      "dependentPossessive": "stellar",
+      "independentPossessive": "stellars",
+      "reflexive": "stelself"
+    },
+    {
+      "subject": "stre",
+      "object": "rem",
+      "dependentPossessive": "tre",
+      "independentPossessive": "trea",
+      "reflexive": "streamself"
+    },
+    {
+      "subject": "stri",
+      "object": "rin",
+      "dependentPossessive": "tri",
+      "independentPossessive": "trin",
+      "reflexive": "stringself"
+    },
+    {
+      "subject": "stri",
+      "object": "string",
+      "dependentPossessive": "stris",
+      "independentPossessive": "strings",
+      "reflexive": "stringself"
+    },
+    {
+      "subject": "su",
+      "object": "sub",
+      "dependentPossessive": "wa",
+      "independentPossessive": "way",
+      "reflexive": "subwayself"
+    },
+    {
+      "subject": "su",
+      "object": "succu",
+      "dependentPossessive": "bus",
+      "independentPossessive": "bus",
+      "reflexive": "succuself"
+    },
+    {
+      "subject": "su",
+      "object": "succu",
+      "dependentPossessive": "cus",
+      "independentPossessive": "cus",
+      "reflexive": "succuself"
+    },
+    {
+      "subject": "su",
+      "object": "sucre",
+      "dependentPossessive": "cres",
+      "independentPossessive": "cres",
+      "reflexive": "sucreself"
+    },
+    {
+      "subject": "su",
+      "object": "sugar",
+      "dependentPossessive": "sugar",
+      "independentPossessive": "sugars",
+      "reflexive": "sugarself"
+    },
+    {
+      "subject": "su",
+      "object": "sugary",
+      "dependentPossessive": "sugar",
+      "independentPossessive": "sugars",
+      "reflexive": "sugaryself"
+    },
+    {
+      "subject": "su",
+      "object": "sul",
+      "dependentPossessive": "hai",
+      "independentPossessive": "hail",
+      "reflexive": "suhailself"
+    },
+    {
+      "subject": "su",
+      "object": "sul",
+      "dependentPossessive": "ul",
+      "independentPossessive": "ulu",
+      "reflexive": "suluself"
+    },
+    {
+      "subject": "su",
+      "object": "sum",
+      "dependentPossessive": "summer",
+      "independentPossessive": "summers",
+      "reflexive": "summerself"
+    },
+    {
+      "subject": "su",
+      "object": "sun",
+      "dependentPossessive": "sund",
+      "independentPossessive": "sunda",
+      "reflexive": "sundayself"
+    },
+    {
+      "subject": "succu",
+      "object": "lent",
+      "dependentPossessive": "cus",
+      "independentPossessive": "cus",
+      "reflexive": "succuself"
+    },
+    {
+      "subject": "succu",
+      "object": "lent",
+      "dependentPossessive": "lents",
+      "independentPossessive": "lents",
+      "reflexive": "succuself"
+    },
+    {
+      "subject": "sui",
+      "object": "suite",
+      "dependentPossessive": "suites",
+      "independentPossessive": "suites",
+      "reflexive": "suiteself"
+    },
+    {
+      "subject": "swa",
+      "object": "swam",
+      "dependentPossessive": "wam",
+      "independentPossessive": "wamp",
+      "reflexive": "swampself"
+    },
+    {
+      "subject": "swa",
+      "object": "swan",
+      "dependentPossessive": "an",
+      "independentPossessive": "wan",
+      "reflexive": "swanself"
+    },
+    {
+      "subject": "swi",
+      "object": "swirl",
+      "dependentPossessive": "swir",
+      "independentPossessive": "swirls",
+      "reflexive": "swirlself"
+    },
+    {
+      "subject": "sy",
+      "object": "rup",
+      "dependentPossessive": "syr",
+      "independentPossessive": "syr",
+      "reflexive": "syrupself"
+    },
+    {
+      "subject": "sy",
+      "object": "syr",
+      "dependentPossessive": "rin",
+      "independentPossessive": "ringa",
+      "reflexive": "syringaself"
+    },
+    {
+      "subject": "sy",
+      "object": "sys",
+      "dependentPossessive": "sys",
+      "independentPossessive": "sys",
+      "reflexive": "sysself"
+    },
+    {
+      "subject": "sym",
+      "object": "symph",
+      "dependentPossessive": "phons",
+      "independentPossessive": "phons",
+      "reflexive": "symphself"
+    },
+    {
+      "subject": "s’mo",
+      "object": "s’mores",
+      "dependentPossessive": "s’more",
+      "independentPossessive": "s’mores",
+      "reflexive": "s’moreself"
+    },
+    {
+      "subject": "t",
+      "object": "t",
+      "dependentPossessive": "t’s",
+      "independentPossessive": "t’s",
+      "reflexive": "tself"
+    },
+    {
+      "subject": "ta",
+      "object": "ant",
+      "dependentPossessive": "res",
+      "independentPossessive": "tares",
+      "reflexive": "antareself"
+    },
+    {
+      "subject": "ta",
+      "object": "on",
+      "dependentPossessive": "tar",
+      "independentPossessive": "tari",
+      "reflexive": "ontarioself"
+    },
+    {
+      "subject": "ta",
+      "object": "taf",
+      "dependentPossessive": "taffet",
+      "independentPossessive": "taffeta",
+      "reflexive": "taffetaself"
+    },
+    {
+      "subject": "ta",
+      "object": "taho",
+      "dependentPossessive": "tahs",
+      "independentPossessive": "tahs",
+      "reflexive": "tahoself"
+    },
+    {
+      "subject": "ta",
+      "object": "taig",
+      "dependentPossessive": "ga",
+      "independentPossessive": "aiga",
+      "reflexive": "taigaself"
+    },
+    {
+      "subject": "ta",
+      "object": "tal",
+      "dependentPossessive": "met",
+      "independentPossessive": "meta",
+      "reflexive": "metalself"
+    },
+    {
+      "subject": "ta",
+      "object": "tan",
+      "dependentPossessive": "tas",
+      "independentPossessive": "tasma",
+      "reflexive": "tasmanself"
+    },
+    {
+      "subject": "ta",
+      "object": "tar",
+      "dependentPossessive": "tarra",
+      "independentPossessive": "tarrag",
+      "reflexive": "tarragonself"
+    },
+    {
+      "subject": "ta",
+      "object": "tar",
+      "dependentPossessive": "tars",
+      "independentPossessive": "tars",
+      "reflexive": "tarself"
+    },
+    {
+      "subject": "ta",
+      "object": "tart",
+      "dependentPossessive": "tar",
+      "independentPossessive": "tarts",
+      "reflexive": "tartself"
+    },
+    {
+      "subject": "ta",
+      "object": "tom",
+      "dependentPossessive": "omi",
+      "independentPossessive": "omic",
+      "reflexive": "atomicself"
+    },
+    {
+      "subject": "ta",
+      "object": "tun",
+      "dependentPossessive": "dra",
+      "independentPossessive": "undra",
+      "reflexive": "tundraself"
+    },
+    {
+      "subject": "taff",
+      "object": "taffy",
+      "dependentPossessive": "taffs",
+      "independentPossessive": "taffs",
+      "reflexive": "taffyself"
+    },
+    {
+      "subject": "tag",
+      "object": "tag",
+      "dependentPossessive": "tags",
+      "independentPossessive": "tags",
+      "reflexive": "tagself"
+    },
+    {
+      "subject": "tama",
+      "object": "rind",
+      "dependentPossessive": "tamar",
+      "independentPossessive": "tamars",
+      "reflexive": "tamaself"
+    },
+    {
+      "subject": "tange",
+      "object": "rine",
+      "dependentPossessive": "rines",
+      "independentPossessive": "rines",
+      "reflexive": "rineself"
+    },
+    {
+      "subject": "tapi",
+      "object": "pioca",
+      "dependentPossessive": "pios",
+      "independentPossessive": "pios",
+      "reflexive": "tapiocaself"
+    },
+    {
+      "subject": "tar",
+      "object": "target",
+      "dependentPossessive": "tar",
+      "independentPossessive": "tars",
+      "reflexive": "targetself"
+    },
+    {
+      "subject": "tau",
+      "object": "tag",
+      "dependentPossessive": "taus",
+      "independentPossessive": "taus",
+      "reflexive": "tauself"
+    },
+    {
+      "subject": "te",
+      "object": "sur",
+      "dependentPossessive": "reas",
+      "independentPossessive": "treas",
+      "reflexive": "treasureself"
+    },
+    {
+      "subject": "te",
+      "object": "teal",
+      "dependentPossessive": "ter",
+      "independentPossessive": "ter",
+      "reflexive": "tealself"
+    },
+    {
+      "subject": "te",
+      "object": "tem",
+      "dependentPossessive": "tempes",
+      "independentPossessive": "tempest",
+      "reflexive": "tempestself"
+    },
+    {
+      "subject": "te",
+      "object": "ten",
+      "dependentPossessive": "ennes",
+      "independentPossessive": "essee",
+      "reflexive": "tennesseeself"
+    },
+    {
+      "subject": "te",
+      "object": "ten",
+      "dependentPossessive": "tenor",
+      "independentPossessive": "tenors",
+      "reflexive": "tenorself"
+    },
+    {
+      "subject": "te",
+      "object": "ten",
+      "dependentPossessive": "teo",
+      "independentPossessive": "teno",
+      "reflexive": "tenorself"
+    },
+    {
+      "subject": "te",
+      "object": "ter",
+      "dependentPossessive": "tem",
+      "independentPossessive": "ters",
+      "reflexive": "temself"
+    },
+    {
+      "subject": "te",
+      "object": "test",
+      "dependentPossessive": "tes",
+      "independentPossessive": "tests",
+      "reflexive": "testself"
+    },
+    {
+      "subject": "te",
+      "object": "tet",
+      "dependentPossessive": "tetra",
+      "independentPossessive": "tetrad",
+      "reflexive": "tetradself"
+    },
+    {
+      "subject": "tem",
+      "object": "temmie",
+      "dependentPossessive": "temmies",
+      "independentPossessive": "temmies",
+      "reflexive": "temmieself"
+    },
+    {
+      "subject": "temp",
+      "object": "tempo",
+      "dependentPossessive": "temps",
+      "independentPossessive": "temps",
+      "reflexive": "tempoself"
+    },
+    {
+      "subject": "tey",
+      "object": "tem",
+      "dependentPossessive": "ter",
+      "independentPossessive": "ters",
+      "reflexive": "temself"
+    },
+    {
+      "subject": "tha",
+      "object": "thrac",
+      "dependentPossessive": "ci",
+      "independentPossessive": "cian",
+      "reflexive": "thracianself"
+    },
+    {
+      "subject": "thae",
+      "object": "thaer",
+      "dependentPossessive": "thaer",
+      "independentPossessive": "thaers",
+      "reflexive": "thaerself"
+    },
+    {
+      "subject": "the",
+      "object": "thet",
+      "dependentPossessive": "thea",
+      "independentPossessive": "theta",
+      "reflexive": "thetaself"
+    },
+    {
+      "subject": "the",
+      "object": "thim",
+      "dependentPossessive": "thir",
+      "independentPossessive": "thirs",
+      "reflexive": "thimself"
+    },
+    {
+      "subject": "thee",
+      "object": "har",
+      "dependentPossessive": "har",
+      "independentPossessive": "hars",
+      "reflexive": "harself"
+    },
+    {
+      "subject": "theme",
+      "object": "theme",
+      "dependentPossessive": "themes",
+      "independentPossessive": "themes",
+      "reflexive": "themeself"
     },
     {
       "subject": "they",
@@ -254,6 +8437,20 @@
       "reflexive": "themselves"
     },
     {
+      "subject": "tho",
+      "object": "thorn",
+      "dependentPossessive": "thorns",
+      "independentPossessive": "thorns",
+      "reflexive": "thornself"
+    },
+    {
+      "subject": "tho",
+      "object": "thought",
+      "dependentPossessive": "thou",
+      "independentPossessive": "though",
+      "reflexive": "thoughtself"
+    },
+    {
       "subject": "thon",
       "object": "thon",
       "dependentPossessive": "thons",
@@ -268,11 +8465,473 @@
       "reflexive": "thonself"
     },
     {
+      "subject": "thra",
+      "object": "ther",
+      "dependentPossessive": "ush",
+      "independentPossessive": "rush",
+      "reflexive": "thrushself"
+    },
+    {
+      "subject": "three",
+      "object": "three",
+      "dependentPossessive": "threes",
+      "independentPossessive": "threes",
+      "reflexive": "threeself"
+    },
+    {
+      "subject": "thu",
+      "object": "thur",
+      "dependentPossessive": "thus",
+      "independentPossessive": "thurs",
+      "reflexive": "thursdayself"
+    },
+    {
+      "subject": "ti",
+      "object": "tiat",
+      "dependentPossessive": "tain",
+      "independentPossessive": "tani",
+      "reflexive": "titaniumself"
+    },
+    {
+      "subject": "ti",
+      "object": "tif",
+      "dependentPossessive": "tis",
+      "independentPossessive": "tifs",
+      "reflexive": "tifself"
+    },
+    {
+      "subject": "ti",
+      "object": "tim",
+      "dependentPossessive": "mor",
+      "independentPossessive": "imor",
+      "reflexive": "timorself"
+    },
+    {
+      "subject": "ti",
+      "object": "tir",
+      "dependentPossessive": "tri",
+      "independentPossessive": "trio",
+      "reflexive": "trioself"
+    },
+    {
+      "subject": "ti",
+      "object": "tir",
+      "dependentPossessive": "tri",
+      "independentPossessive": "triple",
+      "reflexive": "tripleself"
+    },
+    {
+      "subject": "ti",
+      "object": "tul",
+      "dependentPossessive": "ul",
+      "independentPossessive": "uli",
+      "reflexive": "tulipself"
+    },
+    {
+      "subject": "timb",
+      "object": "bre",
+      "dependentPossessive": "bres",
+      "independentPossessive": "bres",
+      "reflexive": "timbreself"
+    },
+    {
+      "subject": "tira",
+      "object": "misu",
+      "dependentPossessive": "tir",
+      "independentPossessive": "tiras",
+      "reflexive": "tiraself"
+    },
+    {
+      "subject": "to",
+      "object": "mis",
+      "dependentPossessive": "misel",
+      "independentPossessive": "miselt",
+      "reflexive": "mistletoeself"
+    },
+    {
+      "subject": "to",
+      "object": "tone",
+      "dependentPossessive": "on",
+      "independentPossessive": "on",
+      "reflexive": "toneself"
+    },
+    {
+      "subject": "to",
+      "object": "top",
+      "dependentPossessive": "topa",
+      "independentPossessive": "topaz",
+      "reflexive": "topazself"
+    },
+    {
+      "subject": "to",
+      "object": "tor",
+      "dependentPossessive": "torna",
+      "independentPossessive": "tornado",
+      "reflexive": "tornadoself"
+    },
+    {
+      "subject": "tod",
+      "object": "tod",
+      "dependentPossessive": "tods",
+      "independentPossessive": "tods",
+      "reflexive": "todself"
+    },
+    {
+      "subject": "toff",
+      "object": "toffee",
+      "dependentPossessive": "toffs",
+      "independentPossessive": "toffs",
+      "reflexive": "toffeeself"
+    },
+    {
+      "subject": "toma",
+      "object": "tom",
+      "dependentPossessive": "toms",
+      "independentPossessive": "toms",
+      "reflexive": "tomself"
+    },
+    {
+      "subject": "tor",
+      "object": "torte",
+      "dependentPossessive": "tor",
+      "independentPossessive": "tors",
+      "reflexive": "torteself"
+    },
+    {
+      "subject": "tori",
+      "object": "toriel",
+      "dependentPossessive": "toriels",
+      "independentPossessive": "toriels",
+      "reflexive": "toriself"
+    },
+    {
+      "subject": "torr",
+      "object": "torrone",
+      "dependentPossessive": "torr",
+      "independentPossessive": "torrs",
+      "reflexive": "torroneself"
+    },
+    {
+      "subject": "tortie",
+      "object": "torti",
+      "dependentPossessive": "torti",
+      "independentPossessive": "tortis",
+      "reflexive": "tortieself"
+    },
+    {
+      "subject": "tortie",
+      "object": "torties",
+      "dependentPossessive": "torties",
+      "independentPossessive": "torties",
+      "reflexive": "tortieself"
+    },
+    {
+      "subject": "tra",
+      "object": "ir",
+      "dependentPossessive": "tri",
+      "independentPossessive": "tria",
+      "reflexive": "atriaself"
+    },
+    {
+      "subject": "tra",
+      "object": "tam",
+      "dependentPossessive": "ra",
+      "independentPossessive": "ram",
+      "reflexive": "tramself"
+    },
+    {
+      "subject": "tra",
+      "object": "ter",
+      "dependentPossessive": "trin",
+      "independentPossessive": "train",
+      "reflexive": "trainself"
+    },
+    {
+      "subject": "tre",
+      "object": "ter",
+      "dependentPossessive": "ree",
+      "independentPossessive": "tree",
+      "reflexive": "treeself"
+    },
+    {
+      "subject": "tre",
+      "object": "treble",
+      "dependentPossessive": "tres",
+      "independentPossessive": "tres",
+      "reflexive": "trebleself"
+    },
+    {
+      "subject": "tri",
+      "object": "tir",
+      "dependentPossessive": "tria",
+      "independentPossessive": "triad",
+      "reflexive": "triadself"
+    },
+    {
+      "subject": "tri",
+      "object": "trifle",
+      "dependentPossessive": "tris",
+      "independentPossessive": "tris",
+      "reflexive": "trifleself"
+    },
+    {
+      "subject": "truff",
+      "object": "ffle",
+      "dependentPossessive": "truffs",
+      "independentPossessive": "truffs",
+      "reflexive": "truffself"
+    },
+    {
+      "subject": "tu",
+      "object": "truth",
+      "dependentPossessive": "tur",
+      "independentPossessive": "true",
+      "reflexive": "truthself"
+    },
+    {
+      "subject": "tu",
+      "object": "tti",
+      "dependentPossessive": "tus",
+      "independentPossessive": "tus",
+      "reflexive": "tuself"
+    },
+    {
+      "subject": "tu",
+      "object": "tue",
+      "dependentPossessive": "tus",
+      "independentPossessive": "tues",
+      "reflexive": "tuesdayself"
+    },
+    {
+      "subject": "tu",
+      "object": "tune",
+      "dependentPossessive": "tunes",
+      "independentPossessive": "tunes",
+      "reflexive": "tuneself"
+    },
+    {
+      "subject": "tu",
+      "object": "tung",
+      "dependentPossessive": "en",
+      "independentPossessive": "sten",
+      "reflexive": "tungstenself"
+    },
+    {
+      "subject": "tu",
+      "object": "turon",
+      "dependentPossessive": "tur",
+      "independentPossessive": "turs",
+      "reflexive": "turonself"
+    },
+    {
+      "subject": "tu",
+      "object": "turquo",
+      "dependentPossessive": "tur",
+      "independentPossessive": "turquoise",
+      "reflexive": "turquoiself"
+    },
+    {
+      "subject": "tul",
+      "object": "tulip",
+      "dependentPossessive": "tulips",
+      "independentPossessive": "tulips",
+      "reflexive": "tulipself"
+    },
+    {
+      "subject": "tutti",
+      "object": "frutti",
+      "dependentPossessive": "tuttis",
+      "independentPossessive": "truttis",
+      "reflexive": "tuttiself"
+    },
+    {
+      "subject": "tux",
+      "object": "tuxedo",
+      "dependentPossessive": "tux",
+      "independentPossessive": "tuxes",
+      "reflexive": "tuxself"
+    },
+    {
+      "subject": "twink",
+      "object": "twink",
+      "dependentPossessive": "twinkle",
+      "independentPossessive": "twinkles",
+      "reflexive": "twinkself"
+    },
+    {
+      "subject": "two",
+      "object": "two",
+      "dependentPossessive": "twos",
+      "independentPossessive": "twos",
+      "reflexive": "twoself"
+    },
+    {
+      "subject": "ty",
+      "object": "tym",
+      "dependentPossessive": "tyme",
+      "independentPossessive": "tymes",
+      "reflexive": "tymeself"
+    },
+    {
+      "subject": "ty",
+      "object": "type",
+      "dependentPossessive": "types",
+      "independentPossessive": "types",
+      "reflexive": "typeself"
+    },
+    {
+      "subject": "ty",
+      "object": "tyr",
+      "dependentPossessive": "rhen",
+      "independentPossessive": "rheni",
+      "reflexive": "tyrrhenianself"
+    },
+    {
+      "subject": "tyr",
+      "object": "tyr",
+      "dependentPossessive": "tyrs",
+      "independentPossessive": "tyrs",
+      "reflexive": "tyrself"
+    },
+    {
+      "subject": "ube",
+      "object": "ube",
+      "dependentPossessive": "ubes",
+      "independentPossessive": "ubes",
+      "reflexive": "ubeself"
+    },
+    {
+      "subject": "ue",
+      "object": "ue",
+      "dependentPossessive": "u’s",
+      "independentPossessive": "u’s",
+      "reflexive": "uself"
+    },
+    {
+      "subject": "un",
+      "object": "und",
+      "dependentPossessive": "unds",
+      "independentPossessive": "unds",
+      "reflexive": "undyneself"
+    },
+    {
+      "subject": "uni",
+      "object": "corn",
+      "dependentPossessive": "unis",
+      "independentPossessive": "unis",
+      "reflexive": "uniself"
+    },
+    {
+      "subject": "v",
+      "object": "v",
+      "dependentPossessive": "v’s",
+      "independentPossessive": "v’s",
+      "reflexive": "vself"
+    },
+    {
+      "subject": "va",
+      "object": "val",
+      "dependentPossessive": "vae",
+      "independentPossessive": "vale",
+      "reflexive": "valeself"
+    },
+    {
+      "subject": "va",
+      "object": "val",
+      "dependentPossessive": "vale",
+      "independentPossessive": "valley",
+      "reflexive": "valleyself"
+    },
+    {
+      "subject": "va",
+      "object": "val",
+      "dependentPossessive": "valo",
+      "independentPossessive": "valor",
+      "reflexive": "valorself"
+    },
+    {
+      "subject": "va",
+      "object": "van",
+      "dependentPossessive": "vanil",
+      "independentPossessive": "vani",
+      "reflexive": "vanillaself"
+    },
+    {
+      "subject": "val",
+      "object": "value",
+      "dependentPossessive": "vals",
+      "independentPossessive": "vals",
+      "reflexive": "valueself"
+    },
+    {
+      "subject": "var",
+      "object": "var",
+      "dependentPossessive": "vars",
+      "independentPossessive": "vars",
+      "reflexive": "varself"
+    },
+    {
+      "subject": "ve",
+      "object": "mon",
+      "dependentPossessive": "ver",
+      "independentPossessive": "verm",
+      "reflexive": "vermontself"
+    },
+    {
+      "subject": "ve",
+      "object": "vaer",
+      "dependentPossessive": "vaers",
+      "independentPossessive": "vaers",
+      "reflexive": "vaerself"
+    },
+    {
+      "subject": "ve",
+      "object": "veg",
+      "dependentPossessive": "ga",
+      "independentPossessive": "ega",
+      "reflexive": "vegaself"
+    },
+    {
+      "subject": "ve",
+      "object": "vel",
+      "dependentPossessive": "vel",
+      "independentPossessive": "velve",
+      "reflexive": "velvetself"
+    },
+    {
+      "subject": "ve",
+      "object": "vem",
+      "dependentPossessive": "ver",
+      "independentPossessive": "vers",
+      "reflexive": "vemself"
+    },
+    {
       "subject": "ve",
       "object": "vem",
       "dependentPossessive": "vir",
       "independentPossessive": "virs",
       "reflexive": "vemself"
+    },
+    {
+      "subject": "ve",
+      "object": "ven",
+      "dependentPossessive": "veen",
+      "independentPossessive": "vens",
+      "reflexive": "venself"
+    },
+    {
+      "subject": "ve",
+      "object": "ven",
+      "dependentPossessive": "ver",
+      "independentPossessive": "vers",
+      "reflexive": "verself"
+    },
+    {
+      "subject": "ve",
+      "object": "ver",
+      "dependentPossessive": "veir",
+      "independentPossessive": "veirs",
+      "reflexive": "verself"
     },
     {
       "subject": "ve",
@@ -282,11 +8941,368 @@
       "reflexive": "verself"
     },
     {
+      "subject": "ver",
+      "object": "ver",
+      "dependentPossessive": "ver",
+      "independentPossessive": "vers",
+      "reflexive": "verself"
+    },
+    {
+      "subject": "vi",
+      "object": "av",
+      "dependentPossessive": "vio",
+      "independentPossessive": "vior",
+      "reflexive": "aviorself"
+    },
+    {
+      "subject": "vi",
+      "object": "san",
+      "dependentPossessive": "vis",
+      "independentPossessive": "visay",
+      "reflexive": "visayanself"
+    },
+    {
+      "subject": "vi",
+      "object": "vib",
+      "dependentPossessive": "bra",
+      "independentPossessive": "brant",
+      "reflexive": "vibrantself"
+    },
+    {
+      "subject": "vi",
+      "object": "vil",
+      "dependentPossessive": "vila",
+      "independentPossessive": "vilai",
+      "reflexive": "villainself"
+    },
+    {
+      "subject": "vi",
+      "object": "viol",
+      "dependentPossessive": "viols",
+      "independentPossessive": "viols",
+      "reflexive": "violself"
+    },
+    {
+      "subject": "vi",
+      "object": "vir",
+      "dependentPossessive": "gi",
+      "independentPossessive": "gini",
+      "reflexive": "virginiaself"
+    },
+    {
+      "subject": "vi",
+      "object": "vir",
+      "dependentPossessive": "virt",
+      "independentPossessive": "virtu",
+      "reflexive": "virtueself"
+    },
+    {
+      "subject": "vi",
+      "object": "vir",
+      "dependentPossessive": "virt",
+      "independentPossessive": "virtu",
+      "reflexive": "virtuself"
+    },
+    {
+      "subject": "vin",
+      "object": "vin",
+      "dependentPossessive": "vins",
+      "independentPossessive": "vins",
+      "reflexive": "vinself"
+    },
+    {
+      "subject": "vine",
+      "object": "vine",
+      "dependentPossessive": "vines",
+      "independentPossessive": "vines",
+      "reflexive": "vineself"
+    },
+    {
+      "subject": "vo",
+      "object": "vol",
+      "dependentPossessive": "vola",
+      "independentPossessive": "volans",
+      "reflexive": "volanself"
+    },
+    {
+      "subject": "voi",
+      "object": "voice",
+      "dependentPossessive": "voice",
+      "independentPossessive": "voices",
+      "reflexive": "voiself"
+    },
+    {
+      "subject": "w",
+      "object": "w",
+      "dependentPossessive": "w’s",
+      "independentPossessive": "w’s",
+      "reflexive": "wself"
+    },
+    {
+      "subject": "wa",
+      "object": "shi",
+      "dependentPossessive": "to",
+      "independentPossessive": "ton",
+      "reflexive": "washingtonself"
+    },
+    {
+      "subject": "wa",
+      "object": "wad",
+      "dependentPossessive": "den",
+      "independentPossessive": "adden",
+      "reflexive": "waddenself"
+    },
+    {
+      "subject": "wa",
+      "object": "wak",
+      "dependentPossessive": "ak",
+      "independentPossessive": "ake",
+      "reflexive": "wakeself"
+    },
+    {
+      "subject": "wa",
+      "object": "wal",
+      "dependentPossessive": "al",
+      "independentPossessive": "alk",
+      "reflexive": "walkself"
+    },
+    {
+      "subject": "wa",
+      "object": "wan",
+      "dependentPossessive": "del",
+      "independentPossessive": "andel",
+      "reflexive": "wandelself"
+    },
+    {
+      "subject": "wa",
+      "object": "wasp",
+      "dependentPossessive": "was",
+      "independentPossessive": "was",
+      "reflexive": "waspself"
+    },
+    {
+      "subject": "wafe",
+      "object": "wafer",
+      "dependentPossessive": "wafer",
+      "independentPossessive": "wafers",
+      "reflexive": "waferself"
+    },
+    {
+      "subject": "wal",
+      "object": "waltz",
+      "dependentPossessive": "altz",
+      "independentPossessive": "altz",
+      "reflexive": "waltzself"
+    },
+    {
+      "subject": "we",
+      "object": "wen",
+      "dependentPossessive": "wens",
+      "independentPossessive": "wensda",
+      "reflexive": "wednesdayself"
+    },
+    {
+      "subject": "we",
+      "object": "west",
+      "dependentPossessive": "es",
+      "independentPossessive": "wes",
+      "reflexive": "westself"
+    },
+    {
+      "subject": "weh",
+      "object": "wedd",
+      "dependentPossessive": "del",
+      "independentPossessive": "eddel",
+      "reflexive": "weddelself"
+    },
+    {
+      "subject": "wen",
+      "object": "digo",
+      "dependentPossessive": "wens",
+      "independentPossessive": "wens",
+      "reflexive": "wenself"
+    },
+    {
+      "subject": "wez",
+      "object": "zen",
+      "dependentPossessive": "wez",
+      "independentPossessive": "zens",
+      "reflexive": "wezself"
+    },
+    {
+      "subject": "whi",
+      "object": "whip",
+      "dependentPossessive": "whips",
+      "independentPossessive": "whips",
+      "reflexive": "whipself"
+    },
+    {
+      "subject": "wi",
+      "object": "scon",
+      "dependentPossessive": "wis",
+      "independentPossessive": "wiscon",
+      "reflexive": "wisconsinself"
+    },
+    {
+      "subject": "wi",
+      "object": "weed",
+      "dependentPossessive": "wis",
+      "independentPossessive": "weeds",
+      "reflexive": "weedself"
+    },
+    {
+      "subject": "wi",
+      "object": "wight",
+      "dependentPossessive": "wis",
+      "independentPossessive": "wighs",
+      "reflexive": "wightself"
+    },
+    {
+      "subject": "wi",
+      "object": "win",
+      "dependentPossessive": "wing",
+      "independentPossessive": "wings",
+      "reflexive": "wingself"
+    },
+    {
+      "subject": "wi",
+      "object": "win",
+      "dependentPossessive": "winkle",
+      "independentPossessive": "winkle",
+      "reflexive": "winkleself"
+    },
+    {
+      "subject": "wi",
+      "object": "win",
+      "dependentPossessive": "wint",
+      "independentPossessive": "wint",
+      "reflexive": "winterself"
+    },
+    {
+      "subject": "wi",
+      "object": "wist",
+      "dependentPossessive": "wis",
+      "independentPossessive": "wister",
+      "reflexive": "wisteriaself"
+    },
+    {
+      "subject": "will",
+      "object": "willow",
+      "dependentPossessive": "willow",
+      "independentPossessive": "willows",
+      "reflexive": "willowself"
+    },
+    {
+      "subject": "winter",
+      "object": "melon",
+      "dependentPossessive": "melons",
+      "independentPossessive": "melons",
+      "reflexive": "melonself"
+    },
+    {
+      "subject": "wish",
+      "object": "wish",
+      "dependentPossessive": "wisher",
+      "independentPossessive": "wishers",
+      "reflexive": "wishself"
+    },
+    {
+      "subject": "wiz",
+      "object": "wiza",
+      "dependentPossessive": "wizar",
+      "independentPossessive": "wizard",
+      "reflexive": "wizardself"
+    },
+    {
+      "subject": "wo",
+      "object": "won",
+      "dependentPossessive": "ond",
+      "independentPossessive": "onder",
+      "reflexive": "wonderself"
+    },
+    {
+      "subject": "wrai",
+      "object": "wraith",
+      "dependentPossessive": "wrair",
+      "independentPossessive": "wrairs",
+      "reflexive": "wraithself"
+    },
+    {
+      "subject": "wre",
+      "object": "wer",
+      "dependentPossessive": "wren",
+      "independentPossessive": "wren",
+      "reflexive": "wrenself"
+    },
+    {
+      "subject": "wre",
+      "object": "wrench",
+      "dependentPossessive": "wres",
+      "independentPossessive": "wres",
+      "reflexive": "wrenchself"
+    },
+    {
+      "subject": "wu",
+      "object": "wood",
+      "dependentPossessive": "woo",
+      "independentPossessive": "woods",
+      "reflexive": "woodself"
+    },
+    {
+      "subject": "wurm",
+      "object": "wurm",
+      "dependentPossessive": "wur",
+      "independentPossessive": "wurs",
+      "reflexive": "wurmself"
+    },
+    {
+      "subject": "wy",
+      "object": "om",
+      "dependentPossessive": "wyo",
+      "independentPossessive": "wyom",
+      "reflexive": "wyomingself"
+    },
+    {
+      "subject": "x",
+      "object": "x",
+      "dependentPossessive": "x’s",
+      "independentPossessive": "x’s",
+      "reflexive": "xself"
+    },
+    {
+      "subject": "x",
+      "object": "xml",
+      "dependentPossessive": "xs",
+      "independentPossessive": "xmls",
+      "reflexive": "xmlself"
+    },
+    {
+      "subject": "xe",
+      "object": "hem",
+      "dependentPossessive": "hir",
+      "independentPossessive": "hirs",
+      "reflexive": "hemself"
+    },
+    {
       "subject": "xe",
       "object": "hir",
       "dependentPossessive": "hir",
       "independentPossessive": "hirs",
       "reflexive": "hirself"
+    },
+    {
+      "subject": "xe",
+      "object": "xem",
+      "dependentPossessive": "xer",
+      "independentPossessive": "xers",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "xe",
+      "object": "xem",
+      "dependentPossessive": "xir",
+      "independentPossessive": "xirs",
+      "reflexive": "xemself"
     },
     {
       "subject": "xe",
@@ -300,7 +9316,21 @@
       "object": "xem",
       "dependentPossessive": "xyr",
       "independentPossessive": "xyrs",
+      "reflexive": "xyemself"
+    },
+    {
+      "subject": "xe",
+      "object": "xem",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
       "reflexive": "xyrself"
+    },
+    {
+      "subject": "xe",
+      "object": "xim",
+      "dependentPossessive": "xir",
+      "independentPossessive": "xirs",
+      "reflexive": "xirself"
     },
     {
       "subject": "xe",
@@ -326,16 +9356,156 @@
     {
       "subject": "xey",
       "object": "xem",
+      "dependentPossessive": "xeir",
+      "independentPossessive": "xeirs",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "xey",
+      "object": "xem",
       "dependentPossessive": "xyr",
       "independentPossessive": "xyrs",
       "reflexive": "xemself"
     },
     {
-      "subject": "ze",
-      "object": "em",
-      "dependentPossessive": "zeir",
-      "independentPossessive": "zeirs",
-      "reflexive": "zeirself"
+      "subject": "xi",
+      "object": "ox",
+      "dependentPossessive": "occi",
+      "independentPossessive": "occipi",
+      "reflexive": "occipitalself"
+    },
+    {
+      "subject": "xi",
+      "object": "xem",
+      "dependentPossessive": "xer",
+      "independentPossessive": "xers",
+      "reflexive": "xemself"
+    },
+    {
+      "subject": "xi",
+      "object": "xic",
+      "dependentPossessive": "xis",
+      "independentPossessive": "xis",
+      "reflexive": "xiself"
+    },
+    {
+      "subject": "xl",
+      "object": "xlsx",
+      "dependentPossessive": "xls",
+      "independentPossessive": "xls",
+      "reflexive": "xlsxself"
+    },
+    {
+      "subject": "xy",
+      "object": "xym",
+      "dependentPossessive": "xys",
+      "independentPossessive": "xyms",
+      "reflexive": "xymself"
+    },
+    {
+      "subject": "xy",
+      "object": "xyr",
+      "dependentPossessive": "xyr",
+      "independentPossessive": "xyrs",
+      "reflexive": "xyrself"
+    },
+    {
+      "subject": "y",
+      "object": "y",
+      "dependentPossessive": "y’s",
+      "independentPossessive": "y’s",
+      "reflexive": "yself"
+    },
+    {
+      "subject": "ya",
+      "object": "ang",
+      "dependentPossessive": "an",
+      "independentPossessive": "yan",
+      "reflexive": "yangself"
+    },
+    {
+      "subject": "ya",
+      "object": "ang",
+      "dependentPossessive": "in",
+      "independentPossessive": "yn",
+      "reflexive": "yayignself"
+    },
+    {
+      "subject": "ye",
+      "object": "yema",
+      "dependentPossessive": "yems",
+      "independentPossessive": "yems",
+      "reflexive": "yemaself"
+    },
+    {
+      "subject": "yel",
+      "object": "yel",
+      "dependentPossessive": "yellows",
+      "independentPossessive": "yellows",
+      "reflexive": "yellowself"
+    },
+    {
+      "subject": "yey",
+      "object": "yem",
+      "dependentPossessive": "yeir",
+      "independentPossessive": "yeirs",
+      "reflexive": "yemself"
+    },
+    {
+      "subject": "yi",
+      "object": "yin",
+      "dependentPossessive": "an",
+      "independentPossessive": "yan",
+      "reflexive": "yiyagnself"
+    },
+    {
+      "subject": "yi",
+      "object": "yin",
+      "dependentPossessive": "in",
+      "independentPossessive": "yn",
+      "reflexive": "yinself"
+    },
+    {
+      "subject": "yin",
+      "object": "yang",
+      "dependentPossessive": "yins",
+      "independentPossessive": "yangs",
+      "reflexive": "yinyangself"
+    },
+    {
+      "subject": "yre",
+      "object": "yre",
+      "dependentPossessive": "yre",
+      "independentPossessive": "yres",
+      "reflexive": "yreself"
+    },
+    {
+      "subject": "yule",
+      "object": "log",
+      "dependentPossessive": "yules",
+      "independentPossessive": "yules",
+      "reflexive": "yulelogself"
+    },
+    {
+      "subject": "z",
+      "object": "z",
+      "dependentPossessive": "z’s",
+      "independentPossessive": "z’s",
+      "reflexive": "zself"
+    },
+    {
+      "subject": "za",
+      "object": "zae",
+      "dependentPossessive": "zas",
+      "independentPossessive": "zas",
+      "reflexive": "zaself"
+    },
+    {
+      "subject": "zae",
+      "object": "zem",
+      "dependentPossessive": "zaer",
+      "independentPossessive": "zaers",
+      "reflexive": "zemself"
     },
     {
       "subject": "ze",
@@ -343,6 +9513,13 @@
       "dependentPossessive": "hir",
       "independentPossessive": "hirs",
       "reflexive": "hirself"
+    },
+    {
+      "subject": "ze",
+      "object": "mer",
+      "dependentPossessive": "mzer",
+      "independentPossessive": "zers",
+      "reflexive": "zemself"
     },
     {
       "subject": "ze",
@@ -361,9 +9538,58 @@
     {
       "subject": "ze",
       "object": "zem",
+      "dependentPossessive": "zeir",
+      "independentPossessive": "zeirs",
+      "reflexive": "zemself"
+    },
+    {
+      "subject": "ze",
+      "object": "zem",
       "dependentPossessive": "zes",
       "independentPossessive": "zes",
       "reflexive": "zirself"
+    },
+    {
+      "subject": "ze",
+      "object": "zeph",
+      "dependentPossessive": "zer",
+      "independentPossessive": "zephyr",
+      "reflexive": "zephyrself"
+    },
+    {
+      "subject": "ze",
+      "object": "zer",
+      "dependentPossessive": "zem",
+      "independentPossessive": "zers",
+      "reflexive": "zemself"
+    },
+    {
+      "subject": "ze",
+      "object": "zero",
+      "dependentPossessive": "zer",
+      "independentPossessive": "zers",
+      "reflexive": "zeroself"
+    },
+    {
+      "subject": "ze",
+      "object": "zet",
+      "dependentPossessive": "zeta",
+      "independentPossessive": "zeta",
+      "reflexive": "zetaself"
+    },
+    {
+      "subject": "ze",
+      "object": "zim",
+      "dependentPossessive": "zees",
+      "independentPossessive": "zees",
+      "reflexive": "zeeself"
+    },
+    {
+      "subject": "ze",
+      "object": "zim",
+      "dependentPossessive": "zis",
+      "independentPossessive": "zis",
+      "reflexive": "zimself"
     },
     {
       "subject": "ze",
@@ -378,6 +9604,62 @@
       "dependentPossessive": "zeta",
       "independentPossessive": "zetas",
       "reflexive": "zedself"
+    },
+    {
+      "subject": "zero",
+      "object": "zero",
+      "dependentPossessive": "zeros",
+      "independentPossessive": "zeros",
+      "reflexive": "zeroself"
+    },
+    {
+      "subject": "zey",
+      "object": "zem",
+      "dependentPossessive": "zeir",
+      "independentPossessive": "zeirs",
+      "reflexive": "zemself"
+    },
+    {
+      "subject": "zhe",
+      "object": "zer",
+      "dependentPossessive": "zer",
+      "independentPossessive": "zers",
+      "reflexive": "zerself"
+    },
+    {
+      "subject": "zhe",
+      "object": "zhim",
+      "dependentPossessive": "zher",
+      "independentPossessive": "zhers",
+      "reflexive": "zherself"
+    },
+    {
+      "subject": "zhe",
+      "object": "zhim",
+      "dependentPossessive": "zher",
+      "independentPossessive": "zhers",
+      "reflexive": "zhimself"
+    },
+    {
+      "subject": "zhe",
+      "object": "zhim",
+      "dependentPossessive": "zhir",
+      "independentPossessive": "zhirs",
+      "reflexive": "zhirself"
+    },
+    {
+      "subject": "zi",
+      "object": "zin",
+      "dependentPossessive": "zin",
+      "independentPossessive": "zinni",
+      "reflexive": "zinniaself"
+    },
+    {
+      "subject": "zi",
+      "object": "zip",
+      "dependentPossessive": "zis",
+      "independentPossessive": "zips",
+      "reflexive": "zipself"
     },
     {
       "subject": "zie",
@@ -413,6 +9695,55 @@
       "dependentPossessive": "zmyr",
       "independentPossessive": "zmyrs",
       "reflexive": "zmyrself"
+    },
+    {
+      "subject": "zo",
+      "object": "az",
+      "dependentPossessive": "azo",
+      "independentPossessive": "azov",
+      "reflexive": "azovself"
+    },
+    {
+      "subject": "zom",
+      "object": "zomb",
+      "dependentPossessive": "zom’s",
+      "independentPossessive": "zombi",
+      "reflexive": "zombself"
+    },
+    {
+      "subject": "zu",
+      "object": "cotto",
+      "dependentPossessive": "cotts",
+      "independentPossessive": "cotts",
+      "reflexive": "zuccottoself"
+    },
+    {
+      "subject": "zu",
+      "object": "zucker",
+      "dependentPossessive": "zucker",
+      "independentPossessive": "zuckers",
+      "reflexive": "zuckerself"
+    },
+    {
+      "subject": "zx",
+      "object": "zxr",
+      "dependentPossessive": "zxr",
+      "independentPossessive": "zxyz",
+      "reflexive": "zxyzself"
+    },
+    {
+      "subject": "é",
+      "object": "clair",
+      "dependentPossessive": "clair",
+      "independentPossessive": "clairs",
+      "reflexive": "éclairself"
+    },
+    {
+      "subject": "ȝe",
+      "object": "ȝim",
+      "dependentPossessive": "ȝer",
+      "independentPossessive": "ȝers",
+      "reflexive": "ȝimself"
     }
   ]
 }


### PR DESCRIPTION
Added a lot of pronoun sets, mostly from [pronoun-provider](http://pronoun-provider.tumblr.com/pronouns).
Some numerical and non-ASCII characters are now included.
I've checked the first quarter or so by eye, and checked the rest by testing for presence/non-presence of `elf` and `elves` endings in correct positions (which is not a hard-and-fast rule).
There's still potential to add more, by correctly parsing specifications of alternatives and by filling in the gaps in sets of 4 or less.
See https://github.com/serin-delaunay/pronounify for full details.
