### PR TITLE
Added a link to the Corpora Hosted by Botwiki project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project is not meant to replace exhaustive APIs -- if you want nouns, and y
 
  * [corpora-project](https://www.npmjs.com/package/corpora-project), a Node.js NPM package for accessing corpora data offline.
  * [pycorpora](https://github.com/aparrish/pycorpora), a simple Python interface for corpora
+ * [Corpora Hosted by Botwiki](https://botwiki.org/projects/corpora/), a free, always-up hosted version of Corpora
  * [corpora-api](https://github.com/coleww/corpora-api), a Node.js server that offers up the corpora as a JSON API
 
 ##I have some data, how do I submit?


### PR DESCRIPTION
Botwiki is now hosting a free, always-up version of this repository. There is a cron job that checks for any changes every hour.

I was originally going to replace the `corpora-api`, as it seems no longer maintained and only available 18 hours a day, but I think that should be someone else's call.