### PR TITLE
New element names!

### DIFF
--- a/data/science/elements.json
+++ b/data/science/elements.json
@@ -567,8 +567,8 @@
         },
         {
             "atomic_number": 114,
-            "name": "Ununquadium",
-            "symbol": "Uuq"
+            "name": "Flerovium",
+            "symbol": "Fl"
         },
         {
             "atomic_number": 115,
@@ -577,8 +577,8 @@
         },
         {
             "atomic_number": 116,
-            "name": "Ununhexium",
-            "symbol": "Uuh"
+            "name": "Livermorium",
+            "symbol": "Lv"
         },
         {
             "atomic_number": 117,

--- a/data/science/elements.json
+++ b/data/science/elements.json
@@ -562,8 +562,8 @@
         },
         {
             "atomic_number": 113,
-            "name": "Ununtrium",
-            "symbol": "Uut"
+            "name": "Nihonium",
+            "symbol": "Nh"
         },
         {
             "atomic_number": 114,
@@ -572,8 +572,8 @@
         },
         {
             "atomic_number": 115,
-            "name": "Ununpentium",
-            "symbol": "Uup"
+            "name": "Moscovium",
+            "symbol": "Mc"
         },
         {
             "atomic_number": 116,
@@ -582,13 +582,13 @@
         },
         {
             "atomic_number": 117,
-            "name": "Ununseptium",
-            "symbol": "Uus"
+            "name": "Tennessine",
+            "symbol": "Ts"
         },
         {
             "atomic_number": 118,
-            "name": "Ununoctium",
-            "symbol": "Uuo"
+            "name": "Oganesson",
+            "symbol": "Og"
         }
     ]
 }


### PR DESCRIPTION
> Elements 113, 115, 117, and 118 are now formally named nihonium (Nh), moscovium (Mc), tennessine (Ts), and oganesson (Og)

https://iupac.org/iupac-announces-the-names-of-the-elements-113-115-117-and-118/

> It’s official: 4 new elements added to periodic table have formal names

https://www.washingtonpost.com/news/morning-mix/wp/2016/12/01/its-official-4-new-elements-added-to-periodic-table-have-formal-names/