### PR TITLE
Remove "gypsy" from adjectives

### DIFF
--- a/data/words/adjs.json
+++ b/data/words/adjs.json
@@ -376,7 +376,6 @@
       "grudging",
       "guaranteed",
       "gusty",
-      "gypsy",
       "half-breed",
       "hand-held",
       "handheld",


### PR DESCRIPTION
It's used as a racial slur ([see](http://gypsyappropriations.blogspot.com/2010/04/problem-with-word-gypsy.html)), and just grates me seeing it in this (otherwise respectful and great!) list of words.