### PR TITLE
Small typo correction in strange_words.json

### DIFF
--- a/data/words/strange_words.json
+++ b/data/words/strange_words.json
@@ -30,7 +30,7 @@
         "dilettante",
         "macrosmatic",
         "supercalifragilisticexpialidocious",
-        "flabergasted",
+        "flabbergasted",
         "sphygmomanometer",
         "Kardashian",
         "hubbub",


### PR DESCRIPTION
"Flabbergasted" has two B's.