### PR TITLE
Update source link for tarot interpretations

### DIFF
--- a/data/divination/tarot_interpretations.json
+++ b/data/divination/tarot_interpretations.json
@@ -1,5 +1,5 @@
 {
-    "description": "Tarot card interpretations, from Mark McElroy's _A Guide to Tarot Meanings_ (http://www.madebymark.com/a-guide-to-tarot-card-meanings/)", 
+    "description": "Tarot card interpretations, from Mark McElroy's _A Guide to Tarot Meanings_ (https://tarottools.com/a-guide-to-tarot-card-meanings/)", 
     "tarot_interpretations": [
         {
             "fortune_telling": [

--- a/data/divination/tarot_interpretations.json
+++ b/data/divination/tarot_interpretations.json
@@ -1,5 +1,5 @@
 {
-    "description": "Tarot card interpretations, from Mark McElroy's _A Guide to Tarot Meanings_ (https://tarottools.com/a-guide-to-tarot-card-meanings/)", 
+    "description": "Tarot card interpretations, from Mark McElroy's _A Guide to Tarot Meanings_ (https://tarottools.com/2014/07/06/my-latest-book-belongs-to-you/)",
     "tarot_interpretations": [
         {
             "fortune_telling": [


### PR DESCRIPTION
The cited author of divination/tarot_interpretations.json, Mark McElroy, seems to have changed his link from <http://www.madebymark.com/a-guide-to-tarot-card-meanings/> (page not found) to <https://tarottools.com/a-guide-to-tarot-card-meanings/>. This new link is referenced in this blog post on the original domain <https://www.madebymark.com/2014/07/06/my-latest-book-belongs-to-you/>.

Thank you for this wonderful project. ❤️ 