### PR TITLE
Use latest Python on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 
-python: 2.7
-
-sudo: false
+python: 3.8
 
 install:
   - npm install


### PR DESCRIPTION
And the `sudo` keyword no longer does anything, we can remove it