### PR TITLE
Validate on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v1
+        with:
+          python-version: '10.x'
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          npm install
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade jsonchecker
+
+      - name: JSON lint
+        shell: bash
+        run: |
+          grunt
+
+      - name: Check for duplicate values
+        shell: bash
+        run: |
+          # Skip this file, it has valid duplicates:
+          rm data/words/verbs_with_conjugations.json
+
+          jsonchecker data --values --quiet


### PR DESCRIPTION
As the Travis CI integration is broken, here's the same validation done using GitHub Actions.

Here's an example run on my fork: 

https://github.com/hugovk/corpora/runs/595248243?check_suite_focus=true

It'll be active on this repo once merged.