### PR TITLE
Add description field to animals data

### DIFF
--- a/data/animals/cats.json
+++ b/data/animals/cats.json
@@ -1,4 +1,5 @@
 {
+   "description": "A list of cat breeds",
    "cats":[
       "Abyssinian",
       "Aegean",

--- a/data/animals/common.json
+++ b/data/animals/common.json
@@ -1,4 +1,5 @@
 {
+  "description": "A list of common types of animals",
   "animals":
     [
       "aardvark",

--- a/data/animals/donkeys.json
+++ b/data/animals/donkeys.json
@@ -1,4 +1,5 @@
 {
+  "description": "A list of donkey breeds",
    "donkeys":[
       "Abkhazskaya",
       "Abyssinian Donkey",

--- a/data/animals/horses.json
+++ b/data/animals/horses.json
@@ -1,4 +1,5 @@
 {
+  "description": "A list of horse breeds",
    "horses":[
       "American Albino",
       "Abaco Barb",

--- a/data/animals/ponies.json
+++ b/data/animals/ponies.json
@@ -1,4 +1,5 @@
 {
+  "description": "A list of pony breeds",
    "ponies":[
       "American Shetland",
       "American Walking Pony",


### PR DESCRIPTION
Adds missing "description" field to cats.json, mirroring dogs.json

**EDIT:** Noticed a couple of other animals JSON files missing a `description` field, tacking those on with this PR.