### PR TITLE
Fixed missing Solomon Islands capital in countries_with_capitals

### DIFF
--- a/data/geography/countries_with_capitals.json
+++ b/data/geography/countries_with_capitals.json
@@ -156,7 +156,7 @@
     {"name":"Singapore", "capital":"Singapore"},
     {"name":"Slovakia", "capital":"Bratislava"},
     {"name":"Slovenia", "capital":"Ljubljana"},
-    {"name":"Solomon Islands", "capital":""},
+    {"name":"Solomon Islands", "capital":"Honiara"},
     {"name":"Somalia", "capital":"Mogadishu"},
     {"name":"South Africa", "capital":"Pretoria"},
 	  {"name":"South Korea", "capital":"Seoul"},


### PR DESCRIPTION
`countries_with_capitals.json` has an empty string for the capital of Solomon Islands. This PR fixes that issue by replacing the empty string with the country's capital [Honiara](https://en.wikipedia.org/wiki/Honiara).